### PR TITLE
"Lincoln" Supporting Views

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -30,6 +30,7 @@ class HomeController extends Controller
 
         $user = $request->user();
         $shows = $user->shows()->where('term_id', $term->id)->get();
+
         return view('home', compact('user', 'shows', 'term'));
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,6 +2,7 @@
 
 namespace KRLX\Http\Controllers;
 
+use KRLX\Term;
 use Illuminate\Http\Request;
 
 class HomeController extends Controller
@@ -24,7 +25,11 @@ class HomeController extends Controller
      */
     public function index(Request $request)
     {
+        $terms = Term::orderByDesc('on_air')->get();
+        $term = $terms->first();
+
         $user = $request->user();
-        return view('home', compact('user'));
+        $shows = $user->shows()->where('term_id', $term->id)->get();
+        return view('home', compact('user', 'shows', 'term'));
     }
 }

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -2,6 +2,8 @@
 
 namespace KRLX\Http\Controllers;
 
+use Illuminate\Http\Request;
+
 class HomeController extends Controller
 {
     /**
@@ -17,10 +19,12 @@ class HomeController extends Controller
     /**
      * Show the application dashboard.
      *
+     * @param  \Illuminate\Http\Request  $request
      * @return \Illuminate\Http\Response
      */
-    public function index()
+    public function index(Request $request)
     {
-        return view('home');
+        $user = $request->user();
+        return view('home', compact('user'));
     }
 }

--- a/app/Http/Controllers/ShowController.php
+++ b/app/Http/Controllers/ShowController.php
@@ -133,18 +133,18 @@ class ShowController extends Controller
         }
 
         $shows = $term->shows->sort(function($a, $b) {
+            $boost_diff = ($b->boost == 'S') <=> ($a->boost == 'S');
             $track_diff = $a->track->order <=> $b->track->order;
             $priority_diff = $a->priority <=> $b->priority;
             $updated_at_diff = $a->updated_at <=> $b->updated_at;
+            $id_diff = $a->id <=> $b->id;
 
-            if ($track_diff != 0) {
-                return $track_diff;
-            } else if ($priority_diff != 0) {
-                return $priority_diff;
-            } else if ($updated_at_diff != 0) {
-                return $updated_at_diff;
-            } else {
-                return $a->id <=> $b->id;
+            $diffs = [$boost_diff, $track_diff, $priority_diff, $updated_at_diff, $id_diff];
+
+            foreach($diffs as $diff) {
+                if($diff != 0) {
+                    return $diff;
+                }
             }
         });
 

--- a/app/Http/Controllers/ShowController.php
+++ b/app/Http/Controllers/ShowController.php
@@ -168,7 +168,7 @@ class ShowController extends Controller
         $hosts = $term->shows->pluck('hosts')->flatten();
         $invitees = $term->shows->pluck('invitees')->flatten();
 
-        $users = $hosts->concat($invitees)->unique(function($user) {
+        $users = $hosts->concat($invitees)->unique(function ($user) {
             return $user['id'];
         })->sortBy('email');
 

--- a/app/Http/Controllers/ShowController.php
+++ b/app/Http/Controllers/ShowController.php
@@ -121,7 +121,7 @@ class ShowController extends Controller
     /**
      * Display the master list of shows.
      *
-     * @param  KRLX\Show  $show
+     * @param  Illuminate\Http\Request  $request
      * @param  KRLX\Term|null  $term
      * @return Illuminate\Http\Response
      */
@@ -149,5 +149,29 @@ class ShowController extends Controller
         });
 
         return view('shows.all', compact('shows', 'terms', 'term'));
+    }
+
+    /**
+     * Display the list of all DJs involved in at least one show.
+     *
+     * @param  Illuminate\Http\Request  $request
+     * @param  KRLX\Term|null  $term
+     * @return Illuminate\Http\Response
+     */
+    public function djs(Request $request, Term $term = null)
+    {
+        $terms = Term::orderByDesc('on_air')->get();
+        if ($term == null) {
+            $term = $terms->first();
+        }
+
+        $hosts = $term->shows->pluck('hosts')->flatten();
+        $invitees = $term->shows->pluck('invitees')->flatten();
+
+        $users = $hosts->concat($invitees)->unique(function($user) {
+            return $user['id'];
+        })->sortBy('email');
+
+        return view('shows.djs', compact('term', 'terms', 'users'));
     }
 }

--- a/app/Http/Controllers/ShowController.php
+++ b/app/Http/Controllers/ShowController.php
@@ -132,7 +132,21 @@ class ShowController extends Controller
             $term = $terms->first();
         }
 
-        $shows = $term->shows->sortBy('updated_at')->sortBy('priority');
+        $shows = $term->shows->sort(function($a, $b) {
+            $track_diff = $a->track->order <=> $b->track->order;
+            $priority_diff = $a->priority <=> $b->priority;
+            $updated_at_diff = $a->updated_at <=> $b->updated_at;
+
+            if ($track_diff != 0) {
+                return $track_diff;
+            } else if ($priority_diff != 0) {
+                return $priority_diff;
+            } else if ($updated_at_diff != 0) {
+                return $updated_at_diff;
+            } else {
+                return $a->id <=> $b->id;
+            }
+        });
 
         return view('shows.all', compact('shows', 'terms', 'term'));
     }

--- a/app/Http/Controllers/ShowController.php
+++ b/app/Http/Controllers/ShowController.php
@@ -132,7 +132,7 @@ class ShowController extends Controller
             $term = $terms->first();
         }
 
-        $shows = $term->shows->sort(function($a, $b) {
+        $shows = $term->shows->sort(function ($a, $b) {
             $boost_diff = ($b->boost == 'S') <=> ($a->boost == 'S');
             $track_diff = $a->track->order <=> $b->track->order;
             $priority_diff = $a->priority <=> $b->priority;
@@ -141,8 +141,8 @@ class ShowController extends Controller
 
             $diffs = [$boost_diff, $track_diff, $priority_diff, $updated_at_diff, $id_diff];
 
-            foreach($diffs as $diff) {
-                if($diff != 0) {
+            foreach ($diffs as $diff) {
+                if ($diff != 0) {
                     return $diff;
                 }
             }

--- a/app/Http/Controllers/ShowController.php
+++ b/app/Http/Controllers/ShowController.php
@@ -132,7 +132,7 @@ class ShowController extends Controller
             $term = $terms->first();
         }
 
-        $shows = $term->shows()->get();
+        $shows = $term->shows->sortBy('updated_at')->sortBy('priority');
 
         return view('shows.all', compact('shows', 'terms', 'term'));
     }

--- a/app/Http/Controllers/ShowController.php
+++ b/app/Http/Controllers/ShowController.php
@@ -117,4 +117,23 @@ class ShowController extends Controller
     {
         return view('shows.review', compact('show'));
     }
+
+    /**
+     * Display the master list of shows.
+     *
+     * @param  KRLX\Show  $show
+     * @param  KRLX\Term|null  $term
+     * @return Illuminate\Http\Response
+     */
+    public function all(Request $request, Term $term = null)
+    {
+        $terms = Term::orderByDesc('on_air')->get();
+        if ($term == null) {
+            $term = $terms->first();
+        }
+
+        $shows = $term->shows()->get();
+
+        return view('shows.all', compact('shows', 'terms', 'term'));
+    }
 }

--- a/app/Listeners/FillUserDefaults.php
+++ b/app/Listeners/FillUserDefaults.php
@@ -36,5 +36,6 @@ class FillUserDefaults
         $user->first_name = $user->first_name ?? $names->first() ?? 'User';
         $user->title = $user->title ?? config('defaults.title', 'KRLX Community');
         $user->photo = $user->photo ?? $icon->getImageDataUri();
+        $user->xp = array_wrap($user->xp) ?? [];
     }
 }

--- a/app/Priority.php
+++ b/app/Priority.php
@@ -49,6 +49,7 @@ class Priority
     public function zone()
     {
         $letters = range('J', 'A');
+
         return $this->terms < count($letters) ? $letters[$this->terms] : 'A';
     }
 }

--- a/app/Priority.php
+++ b/app/Priority.php
@@ -4,65 +4,8 @@ namespace KRLX;
 
 class Priority
 {
-    protected $terms;
-    protected $year;
-
-    function __construct()
-    {
-        $this->terms = 0;
-        $this->year = 0;
-    }
-
-    /**
-     * Get the number of terms this priority corresponds to.
-     *
-     * @return int
-     */
-    public function terms()
-    {
-        return $this->terms;
-    }
-
-    /**
-     * Validates that a new term number is a non-negative integer, and sets the
-     * priority's number of terms if validation passes.
-     *
-     * @param  int  $terms
-     * @return $this
-     */
-    public function setTerms(int $terms)
-    {
-        if($terms >= 0) {
-            $this->terms = $terms;
-        }
-        return $this;
-    }
-
-    /**
-     * Get the year value this priority corresponds to.
-     *
-     * @return int
-     */
-    public function year()
-    {
-        return $this->year;
-    }
-
-    /**
-     * Validates that a new year is a non-negative integer, and is at most 5
-     * larger than the current year. If validation passes, set the year.
-     *
-     * @param  int  $year
-     * @return $this
-     */
-    public function setYear(int $year)
-    {
-        $maxYear = date('Y') + 5;
-        if($year >= 0 and $year <= $maxYear) {
-            $this->year = $year;
-        }
-        return $this;
-    }
+    public $terms = 0;
+    public $year = 0;
 
     /**
      * Get the string representation of this priority.

--- a/app/Priority.php
+++ b/app/Priority.php
@@ -40,4 +40,15 @@ class Priority
     {
         return str_replace(' | ', ' &bull; ', $this->display());
     }
+
+    /**
+     * Get the zone letter corresponding to this priority's terms.
+     *
+     * @return string
+     */
+    public function zone()
+    {
+        $letters = range('J', 'A');
+        return $this->terms < count($letters) ? $letters[$this->terms] : 'A';
+    }
 }

--- a/app/Priority.php
+++ b/app/Priority.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace KRLX;
+
+class Priority
+{
+    protected $terms;
+    protected $year;
+
+    function __construct()
+    {
+        $this->terms = 0;
+        $this->year = 0;
+    }
+
+    /**
+     * Get the number of terms this priority corresponds to.
+     *
+     * @return int
+     */
+    public function terms()
+    {
+        return $this->terms;
+    }
+
+    /**
+     * Validates that a new term number is a non-negative integer, and sets the
+     * priority's number of terms if validation passes.
+     *
+     * @param  int  $terms
+     * @return $this
+     */
+    public function setTerms(int $terms)
+    {
+        if($terms >= 0) {
+            $this->terms = $terms;
+        }
+        return $this;
+    }
+
+    /**
+     * Get the year value this priority corresponds to.
+     *
+     * @return int
+     */
+    public function year()
+    {
+        return $this->year;
+    }
+
+    /**
+     * Validates that a new year is a non-negative integer, and is at most 5
+     * larger than the current year. If validation passes, set the year.
+     *
+     * @param  int  $year
+     * @return $this
+     */
+    public function setYear(int $year)
+    {
+        $maxYear = date('Y') + 5;
+        if($year >= 0 and $year <= $maxYear) {
+            $this->year = $year;
+        }
+        return $this;
+    }
+
+    /**
+     * Get the string representation of this priority.
+     *
+     * @return string
+     */
+    public function display()
+    {
+        $terms = '';
+        if ($this->terms >= count(config('defaults.priority.terms'))) {
+            $terms = config('defaults.priority.default');
+        } else {
+            $terms = config('defaults.priority.terms')[$this->terms];
+        }
+
+        $year = '';
+        if ($this->year >= count(config('defaults.status_codes'))) {
+            $year = $this->year;
+        } else {
+            $year = config('defaults.status_codes')[$this->year];
+        }
+
+        return $terms.' | '.$year;
+    }
+
+    /**
+     * Get the HTML representation of this priority.
+     *
+     * @return string
+     */
+    public function html()
+    {
+        return str_replace(' | ', ' &bull; ', $this->display());
+    }
+}

--- a/app/Show.php
+++ b/app/Show.php
@@ -157,6 +157,8 @@ class Show extends Model
         $year = $priorities->min->year;
         if ($this->track->group !== null) {
             $group = $this->track->group;
+        } elseif ($year == 0) {
+            $zone = config('defaults.priority.none');
         } elseif ($year >= count(config('defaults.status_codes')) and $year < 1000) {
             $zone = config('defaults.priority.default');
         } elseif (strlen($zone) == 2) {

--- a/app/Show.php
+++ b/app/Show.php
@@ -148,7 +148,7 @@ class Show extends Model
         $terms = $priorities->max->terms ?? 0;
         if ($this->track->zone) {
             $zone = $this->track->zone;
-        } else if ($terms >= count(config('defaults.priority.terms'))) {
+        } elseif ($terms >= count(config('defaults.priority.terms'))) {
             $zone = config('defaults.priority.default');
         } else {
             $zone = config('defaults.priority.terms')[$terms];
@@ -157,9 +157,9 @@ class Show extends Model
         $year = $priorities->min->year;
         if ($this->track->group !== null) {
             $group = $this->track->group;
-        } else if ($year >= count(config('defaults.status_codes')) and $year < 1000) {
+        } elseif ($year >= count(config('defaults.status_codes')) and $year < 1000) {
             $zone = config('defaults.priority.default');
-        } else if (strlen($zone) == 2) {
+        } elseif (strlen($zone) == 2) {
             $group = '';
         } else {
             $group = $year - $this->term->year + ($this->term->boosted ? 1 : 0);

--- a/app/Show.php
+++ b/app/Show.php
@@ -155,7 +155,7 @@ class Show extends Model
         }
 
         $year = $priorities->min->year;
-        if ($this->track->group) {
+        if ($this->track->group !== null) {
             $group = $this->track->group;
         } else if ($year >= count(config('defaults.status_codes')) and $year < 1000) {
             $zone = config('defaults.priority.default');

--- a/app/Show.php
+++ b/app/Show.php
@@ -144,8 +144,8 @@ class Show extends Model
      */
     public function getBoostAttribute()
     {
-        if (!$this->boosted) {
-            return null;
+        if (! $this->boosted) {
+            return;
         }
 
         $string = '';
@@ -153,12 +153,12 @@ class Show extends Model
             if ($host->membership->boost == 'S') {
                 $string = 'S';
                 break;
-            } else if ($host->membership->boost == 'A1') {
+            } elseif ($host->membership->boost == 'A1') {
                 $string = 'A1';
-            } else if ($host->membership->boost[0] == '+' and $string != 'A1') {
+            } elseif ($host->membership->boost[0] == '+' and $string != 'A1') {
                 $zones = intval(substr($host->membership->boost));
                 $current_zones = ($string[0] == 'Z' ? intval(substr($string, 2)) : 0);
-                if($zones > $current_zones) {
+                if ($zones > $current_zones) {
                     $string = 'Z+'.$zones;
                 }
             }

--- a/app/Term.php
+++ b/app/Term.php
@@ -84,4 +84,14 @@ class Term extends Model
     {
         return $this->hasMany('KRLX\Show');
     }
+
+    /**
+     * Get the year attached to the term.
+     *
+     * @return int
+     */
+    public function getYearAttribute()
+    {
+        return intval(explode('-', $this->id)[0]);
+    }
 }

--- a/app/Term.php
+++ b/app/Term.php
@@ -74,4 +74,14 @@ class Term extends Model
             return str_replace('_', ' ', title_case($components[1])).' '.$components[0];
         }
     }
+
+    /**
+     * Get the shows attached to this term.
+     *
+     * @return Eloquent\Collection<KRLX\Show>
+     */
+    public function shows()
+    {
+        return $this->hasMany('KRLX\Show');
+    }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -86,6 +86,7 @@ class User extends Authenticatable
         $priority = new Priority;
         $priority->terms = collect($this->xp)->unique()->count();
         $priority->year = $this->year;
+
         return $priority;
     }
 

--- a/app/User.php
+++ b/app/User.php
@@ -45,7 +45,7 @@ class User extends Authenticatable
      * @var array
      */
     protected $casts = [
-        'xp' => 'array'
+        'xp' => 'array',
     ];
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -91,6 +91,21 @@ class User extends Authenticatable
     }
 
     /**
+     * Gets the user's "full name". For Carls and alumni, this appends the class
+     * name onto the end of the user's full name.
+     *
+     * @return string
+     */
+    public function getFullNameAttribute()
+    {
+        if ($this->year >= 1000) {
+            return $this->name." '".substr($this->year, -2);
+        } else {
+            return $this->name;
+        }
+    }
+
+    /**
      * Send a password reset notification.
      *
      * @param  string  $token

--- a/app/User.php
+++ b/app/User.php
@@ -115,6 +115,17 @@ class User extends Authenticatable
     }
 
     /**
+     * Gets the user's "public name", seen by folks who aren't logged in.
+     * TODO: Implement last-name splits.
+     *
+     * @return string
+     */
+    public function getPublicNameAttribute()
+    {
+        return $this->nickname ?? $this->name;
+    }
+
+    /**
      * Send a password reset notification.
      *
      * @param  string  $token

--- a/app/User.php
+++ b/app/User.php
@@ -84,8 +84,8 @@ class User extends Authenticatable
     public function getPriorityAttribute()
     {
         $priority = new Priority;
-        $priority->setTerms(collect($this->xp)->unique()->count())
-                 ->setYear($this->year);
+        $priority->terms = collect($this->xp)->unique()->count();
+        $priority->year = $this->year;
         return $priority;
     }
 

--- a/app/User.php
+++ b/app/User.php
@@ -31,6 +31,15 @@ class User extends Authenticatable
     ];
 
     /**
+     * The attributes that should be added to arrays.
+     *
+     * @var array
+     */
+    protected $appends = [
+        'full_name',
+    ];
+
+    /**
      * The events that should be dispatched.
      *
      * @var array

--- a/app/User.php
+++ b/app/User.php
@@ -40,6 +40,15 @@ class User extends Authenticatable
     ];
 
     /**
+     * The attributes that should be type-cast.
+     *
+     * @var array
+     */
+    protected $casts = [
+        'xp' => 'array'
+    ];
+
+    /**
      * Returns the shows that the user is a member of.
      *
      * @return Eloquent\Collection<KRLX\Show>

--- a/app/User.php
+++ b/app/User.php
@@ -77,6 +77,19 @@ class User extends Authenticatable
     }
 
     /**
+     * Generate the Priority object corresponding to this user.
+     *
+     * @return KRLX\Priority
+     */
+    public function getPriorityAttribute()
+    {
+        $priority = new Priority;
+        $priority->setTerms(collect($this->xp)->unique()->count())
+                 ->setYear($this->year);
+        return $priority;
+    }
+
+    /**
      * Send a password reset notification.
      *
      * @param  string  $token

--- a/config/classes.php
+++ b/config/classes.php
@@ -5,36 +5,295 @@ return [
         ['name' => '"A" classes (M/W/F)', 'classes' => ['1a', '2a', '3a', '4a', '5a', '6a']],
         ['name' => '"C" classes (Tu/Th)', 'classes' => ['1-2c', '2-3c', '4-5c', '5-6c']],
         ['name' => '"L" daily language classes', 'classes' => ['1a-L', '2a-L', '3a-L', '4a-L', '5a-L', '6a-L']],
+        ['name' => 'Art classes', 'classes' => ['mw-am-art', 'mw-pm-art', 'tuth-am-art', 'tuth-pm-art']],
+        ['name' => 'Morning labs', 'classes' => ['m-am-lab', 'tu-am-lab', 'w-am-lab', 'th-am-lab']],
+        ['name' => 'Afternoon labs', 'classes' => ['m-pm-lab', 'tu-pm-lab', 'w-pm-lab', 'th-pm-lab']]
     ],
     'times' => [
-        '1a' => [['days' => ['Monday', 'Wednesday'], 'start' => '08:30', 'end' => '10:00'],
-                 ['days' => ['Friday'], 'start' => '08:30', 'end' => '09:30'], ],
-        '2a' => [['days' => ['Monday', 'Wednesday', 'Friday'], 'start' => '09:30', 'end' => '11:00']],
-        '3a' => [['days' => ['Monday', 'Wednesday'], 'start' => '11:00', 'end' => '12:30'],
-                 ['days' => ['Friday'], 'start' => '12:00', 'end' => '13:00'], ],
-        '4a' => [['days' => ['Monday', 'Wednesday'], 'start' => '12:30', 'end' => '14:00'],
-                 ['days' => ['Friday'], 'start' => '13:00', 'end' => '14:30'], ],
-        '5a' => [['days' => ['Monday', 'Wednesday'], 'start' => '13:30', 'end' => '15:00'],
-                 ['days' => ['Friday'], 'start' => '14:00', 'end' => '15:30'], ],
-        '6a' => [['days' => ['Monday', 'Wednesday'], 'start' => '15:00', 'end' => '16:30'],
-                 ['days' => ['Friday'], 'start' => '15:30', 'end' => '16:30'], ],
-        '1-2c' => [['days' => ['Tuesday', 'Thursday'], 'start' => '08:00', 'end' => '10:00']],
-        '2-3c' => [['days' => ['Tuesday', 'Thursday'], 'start' => '10:00', 'end' => '12:00']],
-        '4-5c' => [['days' => ['Tuesday', 'Thursday'], 'start' => '13:00', 'end' => '15:00']],
-        '5-6c' => [['days' => ['Tuesday', 'Thursday'], 'start' => '15:00', 'end' => '17:00']],
-        '1a-L' => [['days' => ['Monday', 'Wednesday'], 'start' => '08:30', 'end' => '10:00'],
-                   ['days' => ['Friday'], 'start' => '08:30', 'end' => '09:30'],
-                   ['days' => ['Tuesday', 'Thursday'], 'start' => '08:00', 'end' => '09:30'], ],
-        '2a-L' => [['days' => ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'], 'start' => '09:30', 'end' => '11:00']],
-        '3a-L' => [['days' => ['Monday', 'Wednesday'], 'start' => '11:00', 'end' => '12:30'],
-                   ['days' => ['Friday'], 'start' => '12:00', 'end' => '13:00'],
-                   ['days' => ['Tuesday', 'Thursday'], 'start' => '10:30', 'end' => '12:00'], ],
-        '4a-L' => [['days' => ['Monday', 'Wednesday'], 'start' => '12:30', 'end' => '14:00'],
-                   ['days' => ['Tuesday', 'Thursday', 'Friday'], 'start' => '13:00', 'end' => '14:30'], ],
-        '5a-L' => [['days' => ['Monday', 'Wednesday'], 'start' => '13:30', 'end' => '15:00'],
-                   ['days' => ['Friday'], 'start' => '14:00', 'end' => '15:30'],
-                   ['days' => ['Tuesday', 'Thursday'], 'start' => '13:00', 'end' => '14:30'], ],
-        '6a-L' => [['days' => ['Monday', 'Tuesday', 'Wednesday', 'Thursday'], 'start' => '15:00', 'end' => '16:30'],
-                   ['days' => ['Friday'], 'start' => '15:30', 'end' => '16:30'], ],
+        '1a' => [
+            'name' => '1a',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '08:30', 'end' => '09:40'],
+                ['days' => ['Friday'], 'start' => '08:30', 'end' => '09:30'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday', 'Friday'], 'start' => '08:00', 'end' => '10:00']
+            ],
+        ],
+        '2a' => [
+            'name' => '2a',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '09:50', 'end' => '11:00'],
+                ['days' => ['Friday'], 'start' => '09:40', 'end' => '10:40'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '09:30', 'end' => '11:30'],
+                ['days' => ['Friday'], 'start' => '09:30', 'end' => '11:00'],
+            ],
+        ],
+        '3a' => [
+            'name' => '3a',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '11:10', 'end' => '12:20'],
+                ['days' => ['Friday'], 'start' => '12:00', 'end' => '13:00'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '11:00', 'end' => '12:30'],
+                ['days' => ['Friday'], 'start' => '11:30', 'end' => '13:30'],
+            ],
+        ],
+        '4a' => [
+            'name' => '4a',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '12:30', 'end' => '13:40'],
+                ['days' => ['Friday'], 'start' => '13:10', 'end' => '14:10'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '12:00', 'end' => '14:00'],
+                ['days' => ['Friday'], 'start' => '13:00', 'end' => '14:30'],
+            ],
+        ],
+        '5a' => [
+            'name' => '5a',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '13:50', 'end' => '15:00'],
+                ['days' => ['Friday'], 'start' => '14:20', 'end' => '15:20'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '13:30', 'end' => '15:30'],
+                ['days' => ['Friday'], 'start' => '14:00', 'end' => '15:30'],
+            ],
+        ],
+        '6a' => [
+            'name' => '6a',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '15:10', 'end' => '16:20'],
+                ['days' => ['Friday'], 'start' => '15:30', 'end' => '16:30'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '15:00', 'end' => '16:30'],
+                ['days' => ['Friday'], 'start' => '15:00', 'end' => '17:00'],
+            ],
+        ],
+        '1-2c' => [
+            'name' => '1-2c',
+            'displayTimes' => [
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '08:15', 'end' => '10:00'],
+            ],
+            'times' => [
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '08:00', 'end' => '10:30']
+            ],
+        ],
+        '2-3c' => [
+            'name' => '2-3c',
+            'displayTimes' => [
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '10:10', 'end' => '11:55'],
+            ],
+            'times' => [
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '10:00', 'end' => '12:00']
+            ],
+        ],
+        '4-5c' => [
+            'name' => '4-5c',
+            'displayTimes' => [
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '13:15', 'end' => '15:00'],
+            ],
+            'times' => [
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '13:00', 'end' => '15:30']
+            ],
+        ],
+        '5-6c' => [
+            'name' => '5-6c',
+            'displayTimes' => [
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '15:10', 'end' => '16:55'],
+            ],
+            'times' => [
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '15:00', 'end' => '17:00']
+            ],
+        ],
+        '1a-L' => [
+            'name' => '1a Language',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '08:30', 'end' => '09:40'],
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '08:15', 'end' => '09:20'],
+                ['days' => ['Friday'], 'start' => '08:30', 'end' => '09:30'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday', 'Friday'], 'start' => '08:00', 'end' => '10:00'],
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '08:00', 'end' => '09:30']
+            ],
+        ],
+        '2a-L' => [
+            'name' => '2a Language',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '09:50', 'end' => '11:00'],
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '09:30', 'end' => '10:35'],
+                ['days' => ['Friday'], 'start' => '09:40', 'end' => '10:40'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '09:30', 'end' => '11:30'],
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '09:00', 'end' => '11:00'],
+                ['days' => ['Friday'], 'start' => '09:30', 'end' => '11:00']
+            ],
+        ],
+        '3a-L' => [
+            'name' => '3a Language',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '11:10', 'end' => '12:20'],
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '10:45', 'end' => '11:50'],
+                ['days' => ['Friday'], 'start' => '12:00', 'end' => '13:00'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '11:00', 'end' => '12:30'],
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '10:30', 'end' => '12:00'],
+                ['days' => ['Friday'], 'start' => '11:30', 'end' => '13:30'],
+            ],
+        ],
+        '4a-L' => [
+            'name' => '4a Language',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '12:30', 'end' => '13:40'],
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '13:15', 'end' => '14:20'],
+                ['days' => ['Friday'], 'start' => '13:10', 'end' => '14:10'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '12:00', 'end' => '14:00'],
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '13:00', 'end' => '14:30'],
+                ['days' => ['Friday'], 'start' => '13:00', 'end' => '14:30'],
+            ],
+        ],
+        '5a-L' => [
+            'name' => '5a Language',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '13:50', 'end' => '15:00'],
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '15:10', 'end' => '16:15'],
+                ['days' => ['Friday'], 'start' => '14:20', 'end' => '13:20'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '13:30', 'end' => '16:30'],
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '15:00', 'end' => '16:30'],
+                ['days' => ['Friday'], 'start' => '14:00', 'end' => '15:30'],
+            ],
+        ],
+        '6a-L' => [
+            'name' => '6a Language',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '15:10', 'end' => '16:20'],
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '15:10', 'end' => '16:15'],
+                ['days' => ['Friday'], 'start' => '15:30', 'end' => '16:30'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Tuesday', 'Wednesday', 'Thursday'], 'start' => '15:00', 'end' => '16:30'],
+                ['days' => ['Friday'], 'start' => '15:00', 'end' => '17:00'],
+            ],
+        ],
+        'mw-am-art' => [
+            'name' => 'Monday/Wednesday Morning',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '08:30', 'end' => '11:00'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '08:00', 'end' => '11:30'],
+            ],
+        ],
+        'mw-pm-art' => [
+            'name' => 'Monday/Wednesday Afternoon',
+            'displayTimes' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '12:30', 'end' => '15:00'],
+            ],
+            'times' => [
+                ['days' => ['Monday', 'Wednesday'], 'start' => '12:00', 'end' => '15:30'],
+            ],
+        ],
+        'tuth-am-art' => [
+            'name' => 'Tuesday/Thursday Morning',
+            'displayTimes' => [
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '09:00', 'end' => '11:30'],
+            ],
+            'times' => [
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '08:30', 'end' => '12:00'],
+            ],
+        ],
+        'tuth-pm-art' => [
+            'name' => 'Tuesday/Thursday Afternoon',
+            'displayTimes' => [
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '13:15', 'end' => '15:45'],
+            ],
+            'times' => [
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '13:00', 'end' => '16:00'],
+            ],
+        ],
+        'm-am-lab' => [
+            'name' => 'Monday Morning',
+            'displayTimes' => [
+                ['days' => ['Monday'], 'start' => '08:00', 'end' => '12:00'],
+            ],
+            'times' => [
+                ['days' => ['Monday'], 'start' => '07:30', 'end' => '12:30'],
+            ],
+        ],
+        'tu-am-lab' => [
+            'name' => 'Tuesday Morning',
+            'displayTimes' => [
+                ['days' => ['Tuesday'], 'start' => '08:00', 'end' => '12:00'],
+            ],
+            'times' => [
+                ['days' => ['Tuesday'], 'start' => '07:30', 'end' => '12:30'],
+            ],
+        ],
+        'w-am-lab' => [
+            'name' => 'Wednesday Morning',
+            'displayTimes' => [
+                ['days' => ['Wednesday'], 'start' => '08:00', 'end' => '12:00'],
+            ],
+            'times' => [
+                ['days' => ['Wednesday'], 'start' => '07:30', 'end' => '12:30'],
+            ],
+        ],
+        'th-am-lab' => [
+            'name' => 'Thursday Morning',
+            'displayTimes' => [
+                ['days' => ['Thursday'], 'start' => '08:00', 'end' => '12:00'],
+            ],
+            'times' => [
+                ['days' => ['Thursday'], 'start' => '07:30', 'end' => '12:30'],
+            ],
+        ],
+        'm-pm-lab' => [
+            'name' => 'Monday Afternoon',
+            'displayTimes' => [
+                ['days' => ['Monday'], 'start' => '14:00', 'end' => '18:00'],
+            ],
+            'times' => [
+                ['days' => ['Monday'], 'start' => '13:30', 'end' => '18:30'],
+            ],
+        ],
+        'w-pm-lab' => [
+            'name' => 'Wednesday Afternoon',
+            'displayTimes' => [
+                ['days' => ['Wednesday'], 'start' => '14:00', 'end' => '18:00'],
+            ],
+            'times' => [
+                ['days' => ['Wednesday'], 'start' => '13:30', 'end' => '18:30'],
+            ],
+        ],
+        'tu-pm-lab' => [
+            'name' => 'Tuesday Afternoon',
+            'displayTimes' => [
+                ['days' => ['Tuesday'], 'start' => '13:00', 'end' => '17:00'],
+            ],
+            'times' => [
+                ['days' => ['Tuesday'], 'start' => '12:30', 'end' => '17:30'],
+            ],
+        ],
+        'th-pm-lab' => [
+            'name' => 'Thursday Afternoon',
+            'displayTimes' => [
+                ['days' => ['Thursday'], 'start' => '13:00', 'end' => '17:00'],
+            ],
+            'times' => [
+                ['days' => ['Thursday'], 'start' => '12:30', 'end' => '17:30'],
+            ],
+        ],
     ],
 ];

--- a/config/classes.php
+++ b/config/classes.php
@@ -7,7 +7,7 @@ return [
         ['name' => '"L" daily language classes', 'classes' => ['1a-L', '2a-L', '3a-L', '4a-L', '5a-L', '6a-L']],
         ['name' => 'Art classes', 'classes' => ['mw-am-art', 'mw-pm-art', 'tuth-am-art', 'tuth-pm-art']],
         ['name' => 'Morning labs', 'classes' => ['m-am-lab', 'tu-am-lab', 'w-am-lab', 'th-am-lab']],
-        ['name' => 'Afternoon labs', 'classes' => ['m-pm-lab', 'tu-pm-lab', 'w-pm-lab', 'th-pm-lab']]
+        ['name' => 'Afternoon labs', 'classes' => ['m-pm-lab', 'tu-pm-lab', 'w-pm-lab', 'th-pm-lab']],
     ],
     'times' => [
         '1a' => [
@@ -17,7 +17,7 @@ return [
                 ['days' => ['Friday'], 'start' => '08:30', 'end' => '09:30'],
             ],
             'times' => [
-                ['days' => ['Monday', 'Wednesday', 'Friday'], 'start' => '08:00', 'end' => '10:00']
+                ['days' => ['Monday', 'Wednesday', 'Friday'], 'start' => '08:00', 'end' => '10:00'],
             ],
         ],
         '2a' => [
@@ -81,7 +81,7 @@ return [
                 ['days' => ['Tuesday', 'Thursday'], 'start' => '08:15', 'end' => '10:00'],
             ],
             'times' => [
-                ['days' => ['Tuesday', 'Thursday'], 'start' => '08:00', 'end' => '10:30']
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '08:00', 'end' => '10:30'],
             ],
         ],
         '2-3c' => [
@@ -90,7 +90,7 @@ return [
                 ['days' => ['Tuesday', 'Thursday'], 'start' => '10:10', 'end' => '11:55'],
             ],
             'times' => [
-                ['days' => ['Tuesday', 'Thursday'], 'start' => '10:00', 'end' => '12:00']
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '10:00', 'end' => '12:00'],
             ],
         ],
         '4-5c' => [
@@ -99,7 +99,7 @@ return [
                 ['days' => ['Tuesday', 'Thursday'], 'start' => '13:15', 'end' => '15:00'],
             ],
             'times' => [
-                ['days' => ['Tuesday', 'Thursday'], 'start' => '13:00', 'end' => '15:30']
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '13:00', 'end' => '15:30'],
             ],
         ],
         '5-6c' => [
@@ -108,7 +108,7 @@ return [
                 ['days' => ['Tuesday', 'Thursday'], 'start' => '15:10', 'end' => '16:55'],
             ],
             'times' => [
-                ['days' => ['Tuesday', 'Thursday'], 'start' => '15:00', 'end' => '17:00']
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '15:00', 'end' => '17:00'],
             ],
         ],
         '1a-L' => [
@@ -120,7 +120,7 @@ return [
             ],
             'times' => [
                 ['days' => ['Monday', 'Wednesday', 'Friday'], 'start' => '08:00', 'end' => '10:00'],
-                ['days' => ['Tuesday', 'Thursday'], 'start' => '08:00', 'end' => '09:30']
+                ['days' => ['Tuesday', 'Thursday'], 'start' => '08:00', 'end' => '09:30'],
             ],
         ],
         '2a-L' => [
@@ -133,7 +133,7 @@ return [
             'times' => [
                 ['days' => ['Monday', 'Wednesday'], 'start' => '09:30', 'end' => '11:30'],
                 ['days' => ['Tuesday', 'Thursday'], 'start' => '09:00', 'end' => '11:00'],
-                ['days' => ['Friday'], 'start' => '09:30', 'end' => '11:00']
+                ['days' => ['Friday'], 'start' => '09:30', 'end' => '11:00'],
             ],
         ],
         '3a-L' => [

--- a/config/defaults.php
+++ b/config/defaults.php
@@ -4,7 +4,18 @@ return [
     'directory' => 'https://apps.carleton.edu/stock/ldapimage.php?id=',
     'title' => 'KRLX Community',
     'salt' => env('OAUTH_SALT', 'krlx'),
+    'priority' => [
+        'default' => 'A1',
+        'terms' => array_merge(range('J', 'B'), ['A3', 'A2', 'A1'])
+    ],
     'show_id_length' => 6,
+    'status_codes' => [
+        'Non-Carleton',
+        'Faculty',
+        'Staff',
+        'St. Olaf Faculty',
+        'St. Olaf Staff'
+    ],
     'special_times' => [
         'safe-harbor' => [
             'name' => 'Safe Harbor Hours',
@@ -15,7 +26,7 @@ return [
         ],
         'music-mondays' => [
             'name' => 'Music Mondays',
-            'description' => 'KRLX is occasionally played in the dining halls on Mondays. Choose a time during Monday the lunch hour to hear your show played for all of campus to hear!',
+            'description' => 'KRLX is occasionally played in the dining halls on Mondays. Choose a time during the Monday lunch hour to hear your show played for all of campus to hear!',
             'days' => ['Monday'],
             'start' => '11:30',
             'end' => '14:00',

--- a/config/defaults.php
+++ b/config/defaults.php
@@ -6,6 +6,7 @@ return [
     'salt' => env('OAUTH_SALT', 'krlx'),
     'priority' => [
         'default' => 'A1',
+        'none' => 'J4',
         'terms' => array_merge(range('J', 'B'), ['A3', 'A2', 'A1']),
     ],
     'show_id_length' => 6,

--- a/config/defaults.php
+++ b/config/defaults.php
@@ -6,7 +6,7 @@ return [
     'salt' => env('OAUTH_SALT', 'krlx'),
     'priority' => [
         'default' => 'A1',
-        'terms' => array_merge(range('J', 'B'), ['A3', 'A2', 'A1'])
+        'terms' => array_merge(range('J', 'B'), ['A3', 'A2', 'A1']),
     ],
     'show_id_length' => 6,
     'status_codes' => [
@@ -14,7 +14,7 @@ return [
         'Faculty',
         'Staff',
         'St. Olaf Faculty',
-        'St. Olaf Staff'
+        'St. Olaf Staff',
     ],
     'special_times' => [
         'safe-harbor' => [

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -38,6 +38,9 @@ class CreateUsersTable extends Migration
             $table->text('bio')->nullable();
             $table->text('favorite_music')->nullable();
             $table->text('favorite_shows')->nullable();
+
+            // XP
+            $table->text('xp');
         });
     }
 

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -35,3 +35,7 @@ window.to12Hour = function(time) {
 const app = new Vue({
     el: '#app'
 });
+
+$(document).ready(function() {
+    $('[data-toggle="tooltip"]').tooltip();
+})

--- a/resources/assets/js/components/ParticipantList.vue
+++ b/resources/assets/js/components/ParticipantList.vue
@@ -10,7 +10,7 @@
     <tbody>
         <tr v-for="(dj, index) in allDJs" v-bind:id="'dj-row' + index">
             <td class="align-middle">
-                {{ dj.name }}
+                {{ dj.full_name }}
                 <br>
                 <small class="text-muted">{{ dj.email }}</small>
             </td>

--- a/resources/assets/js/components/ParticipantSearch.vue
+++ b/resources/assets/js/components/ParticipantSearch.vue
@@ -7,7 +7,7 @@
             <div class="list-group">
                 <div class="list-group-item d-flex align-items-center" v-for="(dj, index) in suggestions">
                     <div>
-                        {{ dj.name }}
+                        {{ dj.full_name }}
                         <br>
                         <small class="text-muted">{{ dj.email }}</small>
                     </div>

--- a/resources/assets/sass/_variables.scss
+++ b/resources/assets/sass/_variables.scss
@@ -6,3 +6,20 @@ $krlx-red-light: #cc0000;
 // Typography
 $font-family-sans-serif: "Noto Sans", sans-serif;
 $link-color: $krlx-red;
+
+// Priority colors
+$priority: (
+    "a": #1b1c1d,
+    "b": #767676,
+    "c": #6435c9,
+    "d": #2185d0,
+    "e": #00b5ad,
+    "f": #21ba45,
+    "g": #b5cc18,
+    "h": #fbbd08,
+    "i": #f2711c,
+    "j": #db2828,
+    "s": #e8e8e8
+);
+
+$light-priorities: g, h, s;

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -137,3 +137,14 @@ span.onair-now {
 span.text-smallcaps {
     font-variant: small-caps;
 }
+
+@each $zone, $bgcolor in $priority {
+    .bg-priority-#{$zone} {
+        background: $bgcolor;
+        @if index($light-priorities, $zone) {
+            color: #2c3e50;
+        } @else {
+            color: white;
+        }
+    }
+}

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -34,7 +34,7 @@
                             <div class="col-md-8">
                                 <div class="list-group-flush">
                                     @foreach($shows->where('submitted', true) as $show)
-                                        <a class="list-group-item text-dark d-flex align-items-center" href="{{ route('shows.review', $show) }}">
+                                        <a class="list-group-item list-group-item-action text-dark d-flex align-items-center" href="{{ route('shows.review', $show) }}">
                                             <div>
                                                 <h5 class="head-sans-serif mb-0">
                                                     <strong>{{ $show->title }}</strong>
@@ -62,7 +62,7 @@
                             <div class="col-md-8">
                                 <div class="list-group-flush">
                                     @foreach($shows->where('submitted', false) as $show)
-                                        <a class="list-group-item text-dark d-flex align-items-center" href="{{ route('shows.review', $show) }}">
+                                        <a class="list-group-item list-group-item-action text-dark d-flex align-items-center" href="{{ route('shows.review', $show) }}">
                                             <div>
                                                 <h5 class="head-sans-serif mb-0">
                                                     <strong>{{ $show->title }}</strong>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -1,10 +1,14 @@
 @extends('layouts.missioncontrol', ['title' => 'Home'])
 
 @section('head')
-    <p>
-        <a href="{{ route('shows.my') }}" class="btn btn-primary">My Shows</a>
-        <a href="{{ route('shows.create') }}" class="btn btn-primary">Create new radio show</a>
-    </p>
-    <p>(Sorry this doesn't look super glamorous! It should look better soon!)</p>
-    <p>You are currently testing on Beta 1 - v0.5.3 "Wilson IV" - <a href="https://github.com/krlxfm/website/releases/tag/v0.5.3">changelog</a></p>
+    <div class="row">
+        <div class="d-none d-md-block col-md-3 text-center">
+            <img src="{{ $user->photo }}" style="border-radius: 3rem;" class="mb-2" width="100%">
+            {{ $user->email }}
+        </div>
+        <div class="col col-md-9">
+            <h1>Welcome back, {{ $user->first_name }}</h1>
+            <p>You are currently testing on Beta 1 - v0.6.0 "Lincoln" - <a href="https://github.com/krlxfm/website/releases/tag/v0.6.0">changelog</a></p>
+        </div>
+    </div>
 @endsection

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -25,14 +25,14 @@
                         </a>
                     </div>
                 </div>
-                <div class="card-body py-0">
+                <div class="card-body p-0">
                     @if($shows->where('submitted', true)->count() > 0)
                         <div class="row">
-                            <div class="col col-md-4">
-                                <h4 class="mb-0 py-3">Completed shows</h4>
+                            <div class="col-md-4">
+                                <h4 class="mb-0 ml-3 py-3">Completed shows</h4>
                             </div>
-                            <div class="col col-md-8">
-                                <div class="list-group list-group-flush">
+                            <div class="col-md-8">
+                                <div class="list-group-flush">
                                     @foreach($shows->where('submitted', true) as $show)
                                         <a class="list-group-item text-dark d-flex align-items-center" href="{{ route('shows.review', $show) }}">
                                             <div>
@@ -56,11 +56,11 @@
                     @endif
                     @if($shows->where('submitted', false)->count() > 0)
                         <div class="row">
-                            <div class="col col-md-4">
-                                <h4 class="mb-0 py-3">Incomplete shows</h4>
+                            <div class="col-md-4">
+                                <h4 class="mb-0 ml-3 py-3">Incomplete shows</h4>
                             </div>
-                            <div class="col col-md-8">
-                                <div class="list-group list-group-flush">
+                            <div class="col-md-8">
+                                <div class="list-group-flush">
                                     @foreach($shows->where('submitted', false) as $show)
                                         <a class="list-group-item text-dark d-flex align-items-center" href="{{ route('shows.review', $show) }}">
                                             <div>

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -2,13 +2,88 @@
 
 @section('head')
     <div class="row">
-        <div class="d-none d-md-block col-md-3 text-center">
-            <img src="{{ $user->photo }}" style="border-radius: 3rem;" class="mb-2" width="100%">
-            {{ $user->email }}
-        </div>
-        <div class="col col-md-9">
-            <h1>Welcome back, {{ $user->first_name }}</h1>
-            <p>You are currently testing on Beta 1 - v0.6.0 "Lincoln" - <a href="https://github.com/krlxfm/website/releases/tag/v0.6.0">changelog</a></p>
+        <div class="col">
+            <h1 class="text-center mb-1">Mission Control</h1>
+            <p class="text-center mb-4">
+                {{ $user->name }} - {{ $user->email }}
+                @if(ends_with($user->email, "carleton.edu"))
+                    - Priority <span class="badge bg-priority-{{ strtolower($user->priority->zone()) }}">{!! $user->priority->html() !!}</span>
+                @endif
+            </p>
+            <div class="card my-3">
+                <div class="card-header d-flex flex-wrap align-items-center">
+                    <h3 class="mb-0">Radio shows - {{ $term->name }}</h3>
+                    <div class="ml-auto btn-group">
+                        <a href="{{ route('shows.create') }}" class="btn btn-primary btn-sm">
+                            <i class="fas fa-plus"></i> New show
+                        </a>
+                        <a href="{{ route('shows.my') }}" class="d-none d-md-block btn btn-outline-primary btn-sm">
+                            <i class="fas fa-calendar-alt"></i> Past terms
+                        </a>
+                        <a href="#" class="btn btn-outline-primary btn-sm">
+                            <i class="fas fa-user-plus"></i> Join show
+                        </a>
+                    </div>
+                </div>
+                <div class="card-body py-0">
+                    @if($shows->where('submitted', true)->count() > 0)
+                        <div class="row">
+                            <div class="col col-md-4">
+                                <h4 class="mb-0 py-3">Completed shows</h4>
+                            </div>
+                            <div class="col col-md-8">
+                                <div class="list-group list-group-flush">
+                                    @foreach($shows->where('submitted', true) as $show)
+                                        <a class="list-group-item text-dark d-flex align-items-center" href="{{ route('shows.review', $show) }}">
+                                            <div>
+                                                <h5 class="head-sans-serif mb-0">
+                                                    <strong>{{ $show->title }}</strong>
+                                                </h5>
+                                                {{ $show->track->name }} show -
+                                                @if($show->hosts()->count() == 1)
+                                                    Just you
+                                                @else
+                                                    You plus {{ $show->hosts()->count() - 1 }} {{ str_plural('other', $show->hosts()->count() - 1) }}
+                                                @endif
+                                            </div>
+                                            <i class="ml-auto fas fa-chevron-right fa-2x text-muted"></i>
+                                        </a>
+                                    @endforeach
+                                </div>
+                            </div>
+                        </div>
+                        <hr class="my-0">
+                    @endif
+                    @if($shows->where('submitted', false)->count() > 0)
+                        <div class="row">
+                            <div class="col col-md-4">
+                                <h4 class="mb-0 py-3">Incomplete shows</h4>
+                            </div>
+                            <div class="col col-md-8">
+                                <div class="list-group list-group-flush">
+                                    @foreach($shows->where('submitted', false) as $show)
+                                        <a class="list-group-item text-dark d-flex align-items-center" href="{{ route('shows.review', $show) }}">
+                                            <div>
+                                                <h5 class="head-sans-serif mb-0">
+                                                    <strong>{{ $show->title }}</strong>
+                                                </h5>
+                                                {{ $show->track->name }} show -
+                                                @if($show->hosts()->count() == 1)
+                                                    Just you
+                                                @else
+                                                    You plus {{ $show->hosts()->count() - 1 }} {{ str_plural('other', $show->hosts()->count() - 1) }}
+                                                @endif
+                                            </div>
+                                            <i class="ml-auto fas fa-chevron-right fa-2x text-muted"></i>
+                                        </a>
+                                    @endforeach
+                                </div>
+                            </div>
+                        </div>
+                    @endif
+                </div>
+            </div>
         </div>
     </div>
+    <p>You are testing on Beta 1, version 0.6.0 "Lincoln". <a href="https://github.com/krlxfm/website/releases/tag/v0.6.0">View the change log.</a></p>
 @endsection

--- a/resources/views/shows/all.blade.php
+++ b/resources/views/shows/all.blade.php
@@ -49,7 +49,7 @@
                             <td class="align-middle">
                                 {!! implode('<br>', $show->hosts->pluck('name')->all()) !!}
                             </td>
-                            <td class="align-middle bg-priority-{{ strtolower($show->priority[0]) }}">
+                            <td class="align-middle text-center bg-priority-{{ strtolower($show->priority[0]) }}">
                                 {{ $show->track->prefix }}
                                 {{ $show->priority }}
                             </td>
@@ -92,7 +92,7 @@
                             <td class="align-middle">
                                 {!! implode('<br>', $show->hosts->pluck('name')->all()) !!}
                             </td>
-                            <td class="align-middle bg-priority-{{ strtolower($show->priority[0]) }}">
+                            <td class="align-middle text-center bg-priority-{{ strtolower($show->priority[0]) }}">
                                 {{ $show->track->prefix }}
                                 {{ $show->priority }}
                             </td>

--- a/resources/views/shows/all.blade.php
+++ b/resources/views/shows/all.blade.php
@@ -50,6 +50,7 @@
                                 {!! implode('<br>', $show->hosts->pluck('name')->all()) !!}
                             </td>
                             <td class="align-middle">
+                                {{ $show->track->prefix }}
                                 {{ $show->priority }}
                             </td>
                             <td class="align-middle">

--- a/resources/views/shows/all.blade.php
+++ b/resources/views/shows/all.blade.php
@@ -50,6 +50,9 @@
                                 {!! implode('<br>', $show->hosts->pluck('name')->all()) !!}
                             </td>
                             <td class="align-middle text-center bg-priority-{{ strtolower($show->priority[0]) }}">
+                                @if($show->boosted and $show->boost == 'S')
+                                    <i class="fas fa-rocket"></i>
+                                @endif
                                 {{ $show->track->prefix }}
                                 {{ $show->priority }}
                             </td>

--- a/resources/views/shows/all.blade.php
+++ b/resources/views/shows/all.blade.php
@@ -26,7 +26,7 @@
     </div>
     <div class="row">
         <div class="col">
-            <table class="table table-hover">
+            <table class="table table-borderless table-striped">
                 <thead>
                     <tr>
                         <th class="w-50">Title and details</th>
@@ -49,7 +49,7 @@
                             <td class="align-middle">
                                 {!! implode('<br>', $show->hosts->pluck('name')->all()) !!}
                             </td>
-                            <td class="align-middle">
+                            <td class="align-middle bg-priority-{{ strtolower($show->priority[0]) }}">
                                 {{ $show->track->prefix }}
                                 {{ $show->priority }}
                             </td>
@@ -69,7 +69,7 @@
                     <a href="#" class="btn btn-primary"><i class="fas fa-bell"></i> Remind shows</a>
                 </div>
             </div>
-            <table class="table table-hover">
+            <table class="table table-borderless table-striped">
                 <thead>
                     <tr>
                         <th class="w-50">Title and details</th>
@@ -92,7 +92,10 @@
                             <td class="align-middle">
                                 {!! implode('<br>', $show->hosts->pluck('name')->all()) !!}
                             </td>
-                            <td class="align-middle">???</td>
+                            <td class="align-middle bg-priority-{{ strtolower($show->priority[0]) }}">
+                                {{ $show->track->prefix }}
+                                {{ $show->priority }}
+                            </td>
                             <td class="align-middle">
                                 <div class="btn-group">
                                     <a href="{{ route('shows.review', $show) }}" class="btn btn-outline-primary">View/Edit</a>

--- a/resources/views/shows/all.blade.php
+++ b/resources/views/shows/all.blade.php
@@ -1,0 +1,105 @@
+@extends('layouts.missioncontrol', ['title' => 'All Shows'])
+
+@section('head')
+    <div class="row">
+        <div class="col">
+            <div class="d-flex flex-wrap align-items-center">
+                <h1>All Shows</h1>
+                <div class="btn-group ml-auto">
+                    <a href="#" class="btn btn-primary"><i class="fas fa-download"></i> Download CSV</a>
+                </div>
+            </div>
+            <div class="card my-3">
+                <div class="card-body py-2">
+                    <form class="form-inline">
+                        <label class="my-1 mr-2" for="switchTerm">Switch to term:</label>
+                        <select class="custom-select my-1 mr-sm-2" id="switchTerm" name="newTerm">
+                            @foreach($terms as $new_term)
+                                <option value="{{ $new_term->id }}" {{ $new_term->id == $term->id ? 'selected' : '' }}>{{ $new_term->name }}</option>
+                            @endforeach
+                        </select>
+                        <button type="submit" class="btn btn-primary my-1">Go</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th class="w-50">Title and details</th>
+                        <th>Hosts</th>
+                        <th>Priority</th>
+                        <th style="width: 171px">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($shows->where('submitted', true) as $show)
+                        <tr>
+                            <td class="align-middle">
+                                <h5 class="mb-0">{{ $show->title }}</h5>
+                                <small class="text-muted">
+                                    {{ $show->id }} | {{ $show->track->name }} | last updated {{ $show->updated_at->toDayDateTimeString() }}
+                                </small>
+                                <br>
+                                {{ $show->description }}
+                            </td>
+                            <td class="align-middle">
+                                {!! implode('<br>', $show->hosts->pluck('name')->all()) !!}
+                            </td>
+                            <td class="align-middle">???</td>
+                            <td class="align-middle">
+                                <div class="btn-group">
+                                    <a href="{{ route('shows.review', $show) }}" class="btn btn-outline-primary">View/Edit</a>
+                                    <a href="{{ route('shows.review', $show) }}" class="btn btn-outline-danger">Delete</a>
+                                </div>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+            <div class="d-flex mb-3 mt-5 flex-wrap align-items-center">
+                <h2>Incomplete Shows</h2>
+                <div class="btn-group ml-auto">
+                    <a href="#" class="btn btn-primary"><i class="fas fa-bell"></i> Remind shows</a>
+                </div>
+            </div>
+            <table class="table table-hover">
+                <thead>
+                    <tr>
+                        <th class="w-50">Title and details</th>
+                        <th>Hosts</th>
+                        <th>Priority</th>
+                        <th style="width: 171px">Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($shows->where('submitted', false) as $show)
+                        <tr>
+                            <td class="align-middle">
+                                <h5 class="mb-0">{{ $show->title }}</h5>
+                                <small class="text-muted">
+                                    {{ $show->id }} | {{ $show->track->name }} | last updated {{ $show->updated_at->toDayDateTimeString() }}
+                                </small>
+                                <br>
+                                {{ $show->description }}
+                            </td>
+                            <td class="align-middle">
+                                {!! implode('<br>', $show->hosts->pluck('name')->all()) !!}
+                            </td>
+                            <td class="align-middle">???</td>
+                            <td class="align-middle">
+                                <div class="btn-group">
+                                    <a href="{{ route('shows.review', $show) }}" class="btn btn-outline-primary">View/Edit</a>
+                                    <a href="{{ route('shows.review', $show) }}" class="btn btn-outline-danger">Delete</a>
+                                </div>
+                            </td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+@endsection

--- a/resources/views/shows/all.blade.php
+++ b/resources/views/shows/all.blade.php
@@ -85,7 +85,7 @@
                     @foreach($shows->where('submitted', false) as $show)
                         <tr>
                             <td class="align-middle">
-                                <h5 class="mb-0">{{ $show->title }}</h5>
+                                <h5 class="mb-0">{{ $show->title }} <small><span class="badge badge-warning">INCOMPLETE</span></small></h5>
                                 <small class="text-muted">
                                     {{ $show->id }} | {{ $show->track->name }} | last updated {{ $show->updated_at->toDayDateTimeString() }}
                                 </small>

--- a/resources/views/shows/all.blade.php
+++ b/resources/views/shows/all.blade.php
@@ -47,7 +47,7 @@
                                 {{ $show->description }}
                             </td>
                             <td class="align-middle">
-                                {!! implode('<br>', $show->hosts->pluck('name')->all()) !!}
+                                {!! implode('<br>', $show->hosts->pluck('full_name')->all()) !!}
                             </td>
                             <td class="align-middle text-center bg-priority-{{ strtolower($show->priority[0]) }}">
                                 @if($show->boosted and $show->boost == 'S')
@@ -93,7 +93,7 @@
                                 {{ $show->description }}
                             </td>
                             <td class="align-middle">
-                                {!! implode('<br>', $show->hosts->pluck('name')->all()) !!}
+                                {!! implode('<br>', $show->hosts->pluck('full_name')->all()) !!}
                             </td>
                             <td class="align-middle text-center bg-priority-{{ strtolower($show->priority[0]) }}">
                                 {{ $show->track->prefix }}

--- a/resources/views/shows/all.blade.php
+++ b/resources/views/shows/all.blade.php
@@ -49,7 +49,9 @@
                             <td class="align-middle">
                                 {!! implode('<br>', $show->hosts->pluck('name')->all()) !!}
                             </td>
-                            <td class="align-middle">???</td>
+                            <td class="align-middle">
+                                {{ $show->priority }}
+                            </td>
                             <td class="align-middle">
                                 <div class="btn-group">
                                     <a href="{{ route('shows.review', $show) }}" class="btn btn-outline-primary">View/Edit</a>

--- a/resources/views/shows/djs.blade.php
+++ b/resources/views/shows/djs.blade.php
@@ -38,7 +38,7 @@
                     @foreach($users as $user)
                         <tr>
                             <td class="align-middle">
-                                <h5 class="mb-1">{{ $user->name }}</h5>
+                                <h5 class="mb-1">{{ $user->full_name }}</h5>
                                 <ul class="mb-0">
                                     @foreach($user->shows as $show)
                                         <li><a href="{{ route('shows.review', $show) }}">{{ $show->title }}</li>

--- a/resources/views/shows/djs.blade.php
+++ b/resources/views/shows/djs.blade.php
@@ -1,0 +1,59 @@
+@extends('layouts.missioncontrol', ['title' => 'DJ Roster'])
+
+@section('head')
+    <div class="row">
+        <div class="col">
+            <div class="d-flex flex-wrap align-items-center">
+                <h1>DJ roster</h1>
+                <div class="btn-group ml-auto">
+                    <a href="#" class="btn btn-primary"><i class="fas fa-download"></i> Download CSV</a>
+                </div>
+            </div>
+            <div class="card my-3">
+                <div class="card-body py-2">
+                    <form class="form-inline">
+                        <label class="my-1 mr-2" for="switchTerm">Switch to term:</label>
+                        <select class="custom-select my-1 mr-sm-2" id="switchTerm" name="newTerm">
+                            @foreach($terms as $new_term)
+                                <option value="{{ $new_term->id }}" {{ $new_term->id == $term->id ? 'selected' : '' }}>{{ $new_term->name }}</option>
+                            @endforeach
+                        </select>
+                        <button type="submit" class="btn btn-primary my-1">Go</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row">
+        <div class="col">
+            <table class="table table-borderless table-striped">
+                <thead>
+                    <tr>
+                        <th class="w-50">Name and shows</th>
+                        <th>Contact information</th>
+                        <th>XP</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach($users as $user)
+                        <tr>
+                            <td class="align-middle">
+                                <h5 class="mb-1">{{ $user->name }}</h5>
+                                <ul class="mb-0">
+                                    @foreach($user->shows as $show)
+                                        <li><a href="{{ route('shows.review', $show) }}">{{ $show->title }}</li>
+                                    @endforeach
+                                    @foreach($user->invitations as $show)
+                                        <li><a href="{{ route('shows.review', $show) }}">{{ $show->title }}</a> <small class="text-muted">(invitation pending)</small></li>
+                                    @endforeach
+                                </ul>
+                            </td>
+                            <td class="align-middle">{{ $user->email }}</td>
+                            <td class="align-middle text-center bg-priority-{{ strtolower($user->priority->zone()) }}" style="font-size: x-large;">{{ $user->priority->terms }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </div>
+@endsection

--- a/resources/views/shows/hosts.blade.php
+++ b/resources/views/shows/hosts.blade.php
@@ -29,7 +29,7 @@
 <script>
 var showID = "{{ $show->id }}";
 var userID = {{ Auth::user()->id }};
-var participants = {!! json_encode($show->hosts->merge($show->invitees)) !!};
+var participants = {!! json_encode($show->hosts->merge($show->invitees)->unique()) !!};
 </script>
 <script src="/js/pages/shows/hosts.js" defer></script>
 @endpush

--- a/resources/views/shows/review.blade.php
+++ b/resources/views/shows/review.blade.php
@@ -33,8 +33,8 @@
                         <td></td>
                     </tr>
 
-                    @include('shows.tr', ['title' => 'Hosts', 'value' => $show->hosts->pluck('name')->all(), 'path' => 'hosts'])
-                    @include('shows.tr', ['title' => 'Invitees', 'value' => $show->invitees->pluck('name')->all(), 'path' => 'hosts'])
+                    @include('shows.tr', ['title' => 'Hosts', 'value' => $show->hosts->pluck('full_name')->all(), 'path' => 'hosts'])
+                    @include('shows.tr', ['title' => 'Invitees', 'value' => $show->invitees->pluck('full_name')->all(), 'path' => 'hosts'])
 
                     @include('shows.tr', ['title' => 'Title', 'value' => $show->title, 'path' => 'content'])
                     @include('shows.tr', ['title' => 'Description', 'value' => $show->description, 'path' => 'content'])

--- a/resources/views/shows/schedule.blade.php
+++ b/resources/views/shows/schedule.blade.php
@@ -19,7 +19,7 @@
                         <label for="notes" class="col-sm-3 col-md-2 col-form-label">Schedule notes</label>
                         <div class="col-sm-9 col-md-10">
                             <textarea name="notes" class="form-control" id="notes" rows="3">{{ $show->notes }}</textarea>
-                            <small id="notes-help" class="form-text text-muted">If you have anyting to say to us regarding your schedule, say it here. You do <strong>not</strong> need to justify every single conflict you have listed, but please do let us know if there's anything unusual about your schedule.</small>
+                            <small id="notes-help" class="form-text text-muted">If you have anything to say to us regarding your schedule, say it here. You do <strong>not</strong> need to justify every single conflict you have listed, but please do let us know if there's anything unusual about your schedule.</small>
                         </div>
                     </div>
                 </div>

--- a/resources/views/shows/weekly.blade.php
+++ b/resources/views/shows/weekly.blade.php
@@ -46,16 +46,23 @@
     @endforeach
 </div>
 <h2>Classes</h2>
-<p>You can add lab, art, PE, and other class sections in the "Other conflicts" section. We'll automatically round class times to the nearest half hour.</p>
+<p>Most common class times are listed here. PE classes, comps, and St. Olaf class times will need to be entered manually.</p>
 <div class="row mb-3">
     @foreach(config('classes.groups') as $group)
-        <div class="col-sm">
-            <p class="mb-1">{{ $group['name'] }}</p>
+        <div class="col-sm-6 col-md-4 mb-3">
+            <p class="mb-1"><strong>{{ $group['name'] }}</strong></p>
             @foreach($group['classes'] as $block)
+                @php
+                    $dispTimes = array_map(function($time) {
+                        $start = Carbon\Carbon::parse($time['start']);
+                        $end = Carbon\Carbon::parse($time['end']);
+                        return implode(', ', $time['days']).' '.$start->format('g:i a').' - '.$end->format('g:i a');
+                    }, config("classes.times.$block.displayTimes"));
+                @endphp
                 <div class="custom-control custom-checkbox">
                     <input type="checkbox" id="classes-{{ $block }}" name="classes" class="custom-control-input" value="{{ $block }}" {{ in_array($block, $show->classes) ? 'checked' : '' }}>
-                    <label class="custom-control-label" for="classes-{{ $block }}">
-                        {{ $block }}
+                    <label class="custom-control-label" for="classes-{{ $block }}" data-toggle="tooltip" data-placement="bottom" title="{{ implode('; ', $dispTimes) }}">
+                        {{ config("classes.times.$block.name") }}
                     </label>
                 </div>
             @endforeach

--- a/resources/views/shows/weekly.blade.php
+++ b/resources/views/shows/weekly.blade.php
@@ -7,7 +7,7 @@
         <div class="col-sm-10">
             <div class="custom-control custom-radio">
                 <input type="radio" id="length-30" name="preferred_length" class="custom-control-input" value="30" {{ $show->preferred_length == 30 ? 'checked' : '' }}>
-                <label class="custom-control-label" for="length-30">30 minutes</label>
+                <label class="custom-control-label" for="length-30">30 minutes (&frac12; hour)</label>
             </div>
             <div class="custom-control custom-radio">
                 <input type="radio" id="length-60" name="preferred_length" class="custom-control-input" value="60" {{ $show->preferred_length == 60 ? 'checked' : '' }}>

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,6 +28,7 @@ Route::get('/home', 'HomeController@index')->name('home');
 
 Route::middleware('auth')->group(function () {
     Route::get('shows', 'ShowController@my')->name('shows.my');
+    Route::get('shows/all', 'ShowController@all')->name('shows.all');
     Route::get('shows/create', 'ShowController@create')->name('shows.create');
     Route::get('shows/{show}', 'ShowController@review')->name('shows.review');
     Route::get('shows/{show}/hosts', 'ShowController@hosts')->name('shows.hosts');

--- a/routes/web.php
+++ b/routes/web.php
@@ -29,6 +29,7 @@ Route::get('/home', 'HomeController@index')->name('home');
 Route::middleware('auth')->group(function () {
     Route::get('shows', 'ShowController@my')->name('shows.my');
     Route::get('shows/all', 'ShowController@all')->name('shows.all');
+    Route::get('shows/djs', 'ShowController@djs')->name('shows.djs');
     Route::get('shows/create', 'ShowController@create')->name('shows.create');
     Route::get('shows/{show}', 'ShowController@review')->name('shows.review');
     Route::get('shows/{show}/hosts', 'ShowController@hosts')->name('shows.hosts');

--- a/tests/Feature/ShowSupportTest.php
+++ b/tests/Feature/ShowSupportTest.php
@@ -7,7 +7,6 @@ use KRLX\Term;
 use KRLX\User;
 use KRLX\Track;
 use Tests\TestCase;
-use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class ShowSupportTest extends TestCase
@@ -52,7 +51,7 @@ class ShowSupportTest extends TestCase
         $show = factory(Show::class)->create([
             'track_id' => $this->track->id,
             'term_id' => $this->term->id,
-            'submitted' => true
+            'submitted' => true,
         ]);
 
         $request = $this->get('/shows/all');

--- a/tests/Feature/ShowSupportTest.php
+++ b/tests/Feature/ShowSupportTest.php
@@ -71,9 +71,13 @@ class ShowSupportTest extends TestCase
         $user = factory(User::class)->create();
         $this->show->invitees()->attach($user);
 
+        $names = User::get()->sortBy('email')->pluck('name')->map(function($user) {
+            return e($user);
+        });
+
         $request = $this->get('/shows/djs');
         $request->assertOk();
-        $request->assertSeeInOrder(User::get()->sortBy('email')->pluck('name')->all());
+        $request->assertSeeInOrder($names->all());
     }
 
     /**

--- a/tests/Feature/ShowSupportTest.php
+++ b/tests/Feature/ShowSupportTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature;
 
+use Carbon\Carbon;
 use KRLX\Show;
 use KRLX\Term;
 use KRLX\User;
@@ -55,6 +56,57 @@ class ShowSupportTest extends TestCase
         ]);
 
         $request = $this->get('/shows/all');
+        $request->assertOk();
         $request->assertSeeInOrder([$show->title, $this->show->title]);
+    }
+
+    /**
+     * Test that "All Shows" sorts by track order first, then priority, then
+     * submission time.
+     *
+     * @return void
+     */
+    public function testAllShowsSortOrder()
+    {
+        $high_priority_user = factory(User::class)->create([
+            'year' => date('Y') + 2,
+            'xp' => ['2017-WI', '2017-SP', '2017-FA']
+        ]);
+        $mid_priority_user = factory(User::class)->create([
+            'year' => date('Y') + 1,
+            'xp' => ['2017-SP', '2017-FA']
+        ]);
+        $high_priority_track = factory(Track::class)->create([
+            'active' => true,
+            'order' => 900
+        ]);
+        $high_priority_show = factory(Show::class)->create([
+            'track_id' => $this->track->id,
+            'term_id' => $this->term->id,
+            'submitted' => true,
+            'updated_at' => Carbon::now()->subMinutes(20)
+        ]);
+        $recent_show = factory(Show::class)->create([
+            'track_id' => $this->track->id,
+            'term_id' => $this->term->id,
+            'submitted' => true,
+            'updated_at' => Carbon::now()->subMinutes(10)
+        ]);
+        $high_track_show = factory(Show::class)->create([
+            'track_id' => $high_priority_track->id,
+            'term_id' => $this->term->id,
+            'submitted' => true,
+            'updated_at' => Carbon::now()->subMinutes(30)
+        ]);
+
+        $high_priority_show->hosts()->attach($high_priority_user, ['accepted' => true]);
+        $recent_show->hosts()->attach($high_priority_user, ['accepted' => true]);
+        $high_track_show->hosts()->attach($mid_priority_user, ['accepted' => true]);
+
+        $shows = $this->term->shows()->where('submitted', true)->get();
+
+        $request = $this->get('/shows/all');
+        $request->assertOk();
+        $request->assertSeeInOrder([$high_track_show->title, $high_priority_show->title, $recent_show->title]);
     }
 }

--- a/tests/Feature/ShowSupportTest.php
+++ b/tests/Feature/ShowSupportTest.php
@@ -61,6 +61,22 @@ class ShowSupportTest extends TestCase
     }
 
     /**
+     * Test that "All DJs" shows *all* DJs -- invitees and hosts -- who are a
+     * part of any shows.
+     *
+     * @return void
+     */
+    public function testAllDJsReturnsAllUsers()
+    {
+        $user = factory(User::class)->create();
+        $this->show->invitees()->attach($user);
+
+        $request = $this->get('/shows/djs');
+        $request->assertOk();
+        $request->assertSeeInOrder(User::get()->sortBy('email')->pluck('name')->all());
+    }
+
+    /**
      * Test that "All Shows" sorts by track order first, then priority, then
      * submission time.
      *

--- a/tests/Feature/ShowSupportTest.php
+++ b/tests/Feature/ShowSupportTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Tests\Feature;
+
+use KRLX\Show;
+use KRLX\Term;
+use KRLX\User;
+use KRLX\Track;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class ShowSupportTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public $show;
+    public $track;
+    public $term;
+    public $user;
+    public $session;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+        $this->track = factory(Track::class)->create([
+            'active' => true,
+        ]);
+        $this->term = factory(Term::class)->create([
+            'accepting_applications' => true,
+        ]);
+        $this->show = factory(Show::class)->create([
+            'id' => 'SHOW01',
+            'track_id' => $this->track->id,
+            'term_id' => $this->term->id,
+            'submitted' => false,
+        ]);
+        $this->show->hosts()->attach($this->user, ['accepted' => true]);
+        $this->session = $this->actingAs($this->user);
+    }
+
+    /**
+     * Test that "All Shows" shows *all* shows, even those which do not include
+     * the requesting user, and those which have not been submitted yet.
+     *
+     * @return void
+     */
+    public function testAllShowsReturnsAllShows()
+    {
+        $show = factory(Show::class)->create([
+            'track_id' => $this->track->id,
+            'term_id' => $this->term->id,
+            'submitted' => true
+        ]);
+
+        $request = $this->get('/shows/all');
+        $request->assertSeeInOrder([$show->title, $this->show->title]);
+    }
+}

--- a/tests/Feature/ShowSupportTest.php
+++ b/tests/Feature/ShowSupportTest.php
@@ -2,11 +2,11 @@
 
 namespace Tests\Feature;
 
-use Carbon\Carbon;
 use KRLX\Show;
 use KRLX\Term;
 use KRLX\User;
 use KRLX\Track;
+use Carbon\Carbon;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 
@@ -70,33 +70,33 @@ class ShowSupportTest extends TestCase
     {
         $high_priority_user = factory(User::class)->create([
             'year' => date('Y') + 2,
-            'xp' => ['2017-WI', '2017-SP', '2017-FA']
+            'xp' => ['2017-WI', '2017-SP', '2017-FA'],
         ]);
         $mid_priority_user = factory(User::class)->create([
             'year' => date('Y') + 1,
-            'xp' => ['2017-SP', '2017-FA']
+            'xp' => ['2017-SP', '2017-FA'],
         ]);
         $high_priority_track = factory(Track::class)->create([
             'active' => true,
-            'order' => 900
+            'order' => 900,
         ]);
         $high_priority_show = factory(Show::class)->create([
             'track_id' => $this->track->id,
             'term_id' => $this->term->id,
             'submitted' => true,
-            'updated_at' => Carbon::now()->subMinutes(20)
+            'updated_at' => Carbon::now()->subMinutes(20),
         ]);
         $recent_show = factory(Show::class)->create([
             'track_id' => $this->track->id,
             'term_id' => $this->term->id,
             'submitted' => true,
-            'updated_at' => Carbon::now()->subMinutes(10)
+            'updated_at' => Carbon::now()->subMinutes(10),
         ]);
         $high_track_show = factory(Show::class)->create([
             'track_id' => $high_priority_track->id,
             'term_id' => $this->term->id,
             'submitted' => true,
-            'updated_at' => Carbon::now()->subMinutes(30)
+            'updated_at' => Carbon::now()->subMinutes(30),
         ]);
 
         $high_priority_show->hosts()->attach($high_priority_user, ['accepted' => true]);

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Tests\Unit;
+
+use KRLX\User;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class UserTest extends TestCase
+{
+    use RefreshDatabase, WithFaker;
+
+    public $user;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->user = factory(User::class)->create();
+    }
+
+    /**
+     * Test the "Full Name" attribute for standard and Carleton users.
+     *
+     * @return void
+     */
+    public function testFullNameAttribute()
+    {
+        $faker = $this->faker();
+        $user = factory(User::class)->create([
+            'email' => $faker->username.'@carleton.edu',
+            'year' => date('Y')
+        ]);
+
+        $this->assertFalse(ends_with($this->user->email, '@carleton.edu'));
+        $this->assertTrue(ends_with($user->email, '@carleton.edu'));
+
+        $this->assertEquals($this->user->name, $this->user->full_name);
+        $this->assertEquals($user->name." '".date('y'), $user->full_name);
+    }
+}

--- a/tests/Unit/UserTest.php
+++ b/tests/Unit/UserTest.php
@@ -29,7 +29,7 @@ class UserTest extends TestCase
         $faker = $this->faker();
         $user = factory(User::class)->create([
             'email' => $faker->username.'@carleton.edu',
-            'year' => date('Y')
+            'year' => date('Y'),
         ]);
 
         $this->assertFalse(ends_with($this->user->email, '@carleton.edu'));


### PR DESCRIPTION
A few cosmetic changes, and some new web views, and one breaking change to the database! This will bump the version to 0.6.0.

## Backwards compatibility notice

Migrating forward to Lincoln will require a database refresh, as the `xp` column has been added to the users model. If you're installing this on your own, you can complete this change manually by adding a `TEXT NOT NULL` column labeled `xp` and set each user's `xp` to an empty array `[]`.

## New things

- Adds two new views, "All Shows" and "DJ Roster". Closes #41 and closes #42.
- Adds actually useful information to the dashboard. Closes #43.
- Kate had a good idea, which was to add lab times. Standard lab times are now available as class time selection options. Art class times have also been added, so that the art crowd can also be happy. Thanks also to Ann in the registrar's office for putting up with my weird emails. Closes #38.
- Users now have two new fields on them, "Full Name" and "Public Name". They probably won't come into much use in the betas, but will be very useful come public launch. Closes #50, although Public Name still has a few things left to go on it (see #56).
- Implements the priority system. Exactly how terms will appear in a user's `xp` column will come in a future release, but for now, whatever priority you do have will be recognized. Closes #53. (Yeah, I thought this one was coming later too.)

## Bug fixes

- Fixed a few typos that were bothering Kate. Sorry Kate! Closes #39.