### PR TITLE
Show Application Bug Fixes

### DIFF
--- a/app/Http/Requests/ShowUpdateRequest.php
+++ b/app/Http/Requests/ShowUpdateRequest.php
@@ -53,7 +53,7 @@ class ShowUpdateRequest extends FormRequest
             'content' => ['array'],
             'scheduling' => ['array'],
             'conflicts' => ['array', 'min:0'],
-            'preferences' => ['array', 'min:1'],
+            'preferences' => ['array'],
             'etc' => ['array'],
             'special_times' => ['array', 'size:'.count(config('defaults.special_times'))],
             'classes' => ['array'],

--- a/app/Http/Requests/TrackUdpateRequest.php
+++ b/app/Http/Requests/TrackUdpateRequest.php
@@ -51,7 +51,7 @@ class TrackUdpateRequest extends FormRequest
         return [
             $type => ($this->isMethod('PUT') ? 'present|' : '').'nullable|array|min:0',
             "$type.*.title" => 'required|string',
-            "$type.*.db" => 'required|string|regex:[a-z-_]+',
+            "$type.*.db" => 'required|string|regex:/[a-z-_]+/',
             "$type.*.helptext" => 'present|nullable|string',
             "$type.*.type" => 'required|in:'.implode(',', array_keys(config('fields'))),
             "$type.*.rules" => 'present|array|min:0',

--- a/app/Http/Requests/TrackUdpateRequest.php
+++ b/app/Http/Requests/TrackUdpateRequest.php
@@ -51,7 +51,7 @@ class TrackUdpateRequest extends FormRequest
         return [
             $type => ($this->isMethod('PUT') ? 'present|' : '').'nullable|array|min:0',
             "$type.*.title" => 'required|string',
-            "$type.*.db" => 'required|string',
+            "$type.*.db" => 'required|string|regex:[a-z-_]+',
             "$type.*.helptext" => 'present|nullable|string',
             "$type.*.type" => 'required|in:'.implode(',', array_keys(config('fields'))),
             "$type.*.rules" => 'present|array|min:0',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1425,9 +1425,9 @@
             }
         },
         "bootstrap": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.2.tgz",
-            "integrity": "sha512-3bP609EdMc/8EwgGp8KgpN8HwnR4V4lZ9CTi5pImMrXNxpkw7dK1B05aMwQWpG1ZWmTLlBSN/uzkuz5GsmQNFA==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.1.3.tgz",
+            "integrity": "sha512-rDFIzgXcof0jDyjNosjv4Sno77X4KuPeFxG2XZZv1/Kc8DRVGVADdoQyyOVDwPqL36DDmtCQbrpMCqvpPLJQ0w==",
             "dev": true
         },
         "brace-expansion": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     },
     "devDependencies": {
         "axios": "^0.18",
-        "bootstrap": "^4.1.2",
+        "bootstrap": "^4.1.3",
         "cross-env": "^5.1",
         "jquery": "^3.2",
         "laravel-mix": "^2.0",

--- a/resources/assets/js/pages/shows/content.js
+++ b/resources/assets/js/pages/shows/content.js
@@ -4,19 +4,20 @@ function setListeners() {
 }
 
 function submitForm() {
-    var data = $("#content-form").serializeArray();
+    var field = $(this);
     var requestData = {};
-    data.forEach((item) => {
-        if(item.name.indexOf('.') == -1) {
-            requestData[item.name] = item.value
-        } else {
-            var components = item.name.split('.');
-            if (components[0] in requestData === false) requestData[components[0]] = {};
-            requestData[components[0]][components[1]] = item.value;
-        }
-    });
-    delete requestData._method;
-    delete requestData._token;
+    var components = field.attr('name').split('.');
+    if (components.length == 1) {
+        requestData[field.attr('name')] = field.val();
+    } else if (components.length == 2) {
+        var data = $('[name^="'+components[0]+'."]');
+        requestData[components[0]] = {};
+        data.each(function(index, item) {
+            var itemName = $(item).attr('name').split('.')[1];
+            console.log($(item).attr('name').split('.')[1]);
+            requestData[components[0]][itemName] = $(item).val();
+        })
+    }
 
     axios.patch('/api/v1/shows/'+showID, requestData)
     .then((response) => {
@@ -41,8 +42,10 @@ function showValidationErrors(rawErrors) {
         var message = error[1][0];
         var field = $('[name="'+key+'"]');
 
-        field.addClass('is-invalid');
-        field.after('<div class="invalid-feedback">'+message+'</div>');
+        if(field.val().length > 0) {
+            field.addClass('is-invalid');
+            field.after('<div class="invalid-feedback">'+message+'</div>');
+        }
     })
 }
 

--- a/resources/assets/js/pages/shows/content.js
+++ b/resources/assets/js/pages/shows/content.js
@@ -3,38 +3,6 @@ function setListeners() {
     $("input, textarea").change(submitForm)
 }
 
-function submitForm() {
-    var field = $(this);
-    var requestData = {};
-    var components = field.attr('name').split('.');
-    if (components.length == 1) {
-        requestData[field.attr('name')] = field.val();
-    } else if (components.length == 2) {
-        var data = $('[name^="'+components[0]+'."]');
-        requestData[components[0]] = {};
-        data.each(function(index, item) {
-            var itemName = $(item).attr('name').split('.')[1];
-            console.log($(item).attr('name').split('.')[1]);
-            requestData[components[0]][itemName] = $(item).val();
-        })
-    }
-
-    axios.patch('/api/v1/shows/'+showID, requestData)
-    .then((response) => {
-        $("div.invalid-feedback, div.valid-feedback").remove();
-        $(".is-invalid").removeClass('is-invalid');
-        $("#changes-saved-item").show();
-        $("#changes-saved-item").fadeOut(2000);
-    })
-    .catch((error) => {
-        $("div.invalid-feedback, div.valid-feedback").remove();
-        $(".is-invalid").removeClass('is-invalid');
-        if (error.response) {
-            showValidationErrors(error.response.data.errors);
-        }
-    });
-}
-
 function showValidationErrors(rawErrors) {
     var errors = Object.entries(rawErrors);
     errors.forEach((error) => {

--- a/resources/assets/js/pages/shows/content.js
+++ b/resources/assets/js/pages/shows/content.js
@@ -42,6 +42,11 @@ function showValidationErrors(rawErrors) {
         var message = error[1][0];
         var field = $('[name="'+key+'"]');
 
+        if(key.indexOf('.') != -1) {
+            var components = key.split('.');
+            message = message.replace(components[0] + '.', '');
+        }
+
         if(field.val().length > 0) {
             field.addClass('is-invalid');
             field.after('<div class="invalid-feedback">'+message+'</div>');

--- a/resources/assets/js/pages/shows/schedule.js
+++ b/resources/assets/js/pages/shows/schedule.js
@@ -1,31 +1,4 @@
 $(document).ready(function() {
     $("#changes-saved-item").hide();
-    $("#scheduling-form input, #scheduling-form textarea, #scheduling-form select").change(saveData);
+    $("#scheduling-form input, #scheduling-form textarea, #scheduling-form select").change(submitForm);
 })
-
-function saveData() {
-    var data = $("#scheduling-form").serializeArray();
-    var requestData = {classes: []};
-    data.forEach((item) => {
-        if(item.name == 'classes') {
-            requestData.classes.push(item.value);
-        } else if(item.name.indexOf('.') == -1) {
-            requestData[item.name] = item.value;
-        } else {
-            var components = item.name.split('.');
-            if (components[0] in requestData === false) requestData[components[0]] = {};
-            requestData[components[0]][components[1]] = item.value;
-        }
-    });
-    delete requestData._method;
-    delete requestData._token;
-
-    axios.patch('/api/v1/shows/'+showID, requestData)
-    .then((response) => {
-        $("#changes-saved-item").show();
-        $("#changes-saved-item").fadeOut(2000);
-    })
-    .catch((error) => {
-        console.error(error.response.data.errors);
-    });
-}

--- a/resources/assets/js/pages/shows/schedule.js
+++ b/resources/assets/js/pages/shows/schedule.js
@@ -25,4 +25,7 @@ function saveData() {
         $("#changes-saved-item").show();
         $("#changes-saved-item").fadeOut(2000);
     })
+    .catch((error) => {
+        console.error(error.response.data.errors);
+    });
 }

--- a/resources/assets/js/pages/shows/submitform.js
+++ b/resources/assets/js/pages/shows/submitform.js
@@ -1,0 +1,35 @@
+function submitForm() {
+    var field = $(this);
+    var requestData = {};
+    var components = field.attr('name').split('.');
+    if (components.length == 1) {
+        requestData[field.attr('name')] = field.val();
+    } else if (components.length == 2) {
+        var data = $('[name^="'+components[0]+'."]');
+        requestData[components[0]] = {};
+        data.each(function(index, item) {
+            var itemName = $(item).attr('name').split('.')[1];
+            console.log($(item).attr('name').split('.')[1]);
+            requestData[components[0]][itemName] = $(item).val();
+        })
+    }
+
+    return sendUpdateRequest(showID, requestData);
+}
+
+function sendUpdateRequest(showID, data) {
+    axios.patch('/api/v1/shows/'+showID, data)
+    .then((response) => {
+        $("div.invalid-feedback, div.valid-feedback").remove();
+        $(".is-invalid").removeClass('is-invalid');
+        $("#changes-saved-item").show();
+        $("#changes-saved-item").fadeOut(2000);
+    })
+    .catch((error) => {
+        $("div.invalid-feedback, div.valid-feedback").remove();
+        $(".is-invalid").removeClass('is-invalid');
+        if (error.response && showValidationErrors) {
+            showValidationErrors(error.response.data.errors);
+        }
+    });
+}

--- a/resources/assets/js/pages/shows/weekly.js
+++ b/resources/assets/js/pages/shows/weekly.js
@@ -8,28 +8,33 @@ function removeConflict(index) {
 
 function editConflict(index) {
     var conflict = conflicts[index];
-    $('[name="conflict-days"]').prop('checked', false);
-    conflict.days.forEach((day) => {
-        $('#conflict-days-'+day).prop('checked', true);
-    });
-    $("#conflict-start").val(conflict.start);
-    setConflictEndTime();
-    $("#conflict-end").val(conflict.end);
-    $("#conflict-index").val(index);
-    $("#conflict-manager").modal('show');
+    editItem(conflict, 'conflict');
 }
 
 function editPreference(index) {
     var preference = preferences[index];
-    $('[name="preference-days"]').prop('checked', false);
-    preference.days.forEach((day) => {
-        $('#preference-days-'+day).prop('checked', true);
+    $("#preference-strength").val(preference.strength);
+    editItem(preference, 'preference');
+}
+
+function editItem(item, type) {
+    $('[name="'+type+'-days"]').prop('checked', false);
+    item.days.forEach((day) => {
+        $('#'+type+'-days-'+day).prop('checked', true);
     });
-    $("#preference-start").val(preference.start);
-    setPreferenceEndTime();
-    $("#preference-end").val(preference.end);
-    $("#preference-index").val(index);
-    $("#preference-manager").modal('show');
+    $("#"+type+"-start").val(item.start);
+    setEndTime(type);
+    $("#"+type+"-end").val(item.end);
+    $("#"+type+"-index").val(index);
+    $("#"+type+"-manager").modal('show');
+}
+
+function setEndTime(type) {
+    if(type == 'conflict') {
+        setConflictEndTime();
+    } else {
+        setPreferenceEndTime();
+    }
 }
 
 function removeSlot(group, singular, index) {
@@ -66,26 +71,24 @@ function conflictOrPrefToText(item) {
 }
 
 function setConflictEndTime() {
-    var start = moment($("#conflict-start").val(), 'HH:mm');
-    var time = moment(start);
-    $("#conflict-end").empty();
-    for(var i = 0; i < 48; i++) {
-        time.add(30, 'm');
-        $("#conflict-end").append('<option value="'+time.format('HH:mm')+'">'+time.format('h:mm a')+(time.day() == start.day() ? '' : ' (next day)')+'</option>');
-    }
+    populateEndDropdown('conflict');
 }
 
 function setPreferenceEndTime() {
-    var start = moment($("#preference-start").val(), 'HH:mm');
-    var time = moment(start);
-    $("#preference-end").empty();
-    for(var i = 0; i < 48; i++) {
-        time.add(30, 'm');
-        $("#preference-end").append('<option value="'+time.format('HH:mm')+'">'+time.format('h:mm a')+(time.day() == start.day() ? '' : ' (next day)')+'</option>');
-    }
+    populateEndDropdown('preference');
     var slotLength = parseInt($('[name="preferred_length"]:checked').val());
     time = moment(start).add(slotLength, 'm');
     $("#preference-end").val(time.format('HH:mm'));
+}
+
+function populateEndDropdown(menu) {
+    var start = moment($("#"+menu+"-start").val(), 'HH:mm');
+    var time = moment(start);
+    $("#"+menu+"-end").empty();
+    for(var i = 0; i < 48; i++) {
+        time.add(30, 'm');
+        $("#"+menu+"-end").append('<option value="'+time.format('HH:mm')+'">'+time.format('h:mm a')+(time.day() == start.day() ? '' : ' (next day)')+'</option>');
+    }
 }
 
 function showNewConflictModal() {
@@ -136,9 +139,6 @@ function storeScheduleItem(group, list) {
     .then((response) => {
         $("#changes-saved-item").show();
         $("#changes-saved-item").fadeOut(2000);
-    })
-    .catch((error) => {
-        console.error(error.response.data.errors);
     });
 }
 

--- a/resources/assets/js/pages/shows/weekly.js
+++ b/resources/assets/js/pages/shows/weekly.js
@@ -83,6 +83,9 @@ function setPreferenceEndTime() {
         time.add(30, 'm');
         $("#preference-end").append('<option value="'+time.format('HH:mm')+'">'+time.format('h:mm a')+(time.day() == start.day() ? '' : ' (next day)')+'</option>');
     }
+    var slotLength = parseInt($('[name="preferred_length"]:checked').val());
+    time = moment(start).add(slotLength, 'm');
+    $("#preference-end").val(time.format('HH:mm'));
 }
 
 function showNewConflictModal() {
@@ -100,7 +103,6 @@ function showNewPreferenceModal() {
     setPreferenceEndTime();
     $("#preference-index").val(-1);
     $("#preference-strength").val(1);
-    $("#preference-end").val("12:30");
     $("#preference-manager").modal('show');
 }
 

--- a/resources/assets/js/pages/shows/weekly.js
+++ b/resources/assets/js/pages/shows/weekly.js
@@ -132,6 +132,9 @@ function storeScheduleItem(group, list) {
     .then((response) => {
         $("#changes-saved-item").show();
         $("#changes-saved-item").fadeOut(2000);
+    })
+    .catch((error) => {
+        console.error(error.response.data.errors);
     });
     $("#"+group+"-manager").modal('hide');
 }

--- a/resources/assets/js/pages/shows/weekly.js
+++ b/resources/assets/js/pages/shows/weekly.js
@@ -118,17 +118,21 @@ function storeScheduleItem(group, list) {
     };
     if (group == 'preference') item.strength = $("#"+group+"-strength").val();
 
+    $("#"+group+"-manager").modal('hide');
+    if(item.days.length == 0) {
+        return true;
+    }
+
     var index = $("#"+group+"-index").val();
     if(index == -1) {
         list.push(item);
     } else {
         list.splice(index, 1, item);
     }
+    var apiData = {};
+    apiData[group+'s'] = list;
 
-    axios.patch('/api/v1/shows/'+showID, {
-        conflicts: window.conflicts,
-        preferences: window.preferences
-    })
+    axios.patch('/api/v1/shows/'+showID, apiData)
     .then((response) => {
         $("#changes-saved-item").show();
         $("#changes-saved-item").fadeOut(2000);
@@ -136,7 +140,6 @@ function storeScheduleItem(group, list) {
     .catch((error) => {
         console.error(error.response.data.errors);
     });
-    $("#"+group+"-manager").modal('hide');
 }
 
 function savePreference() {

--- a/resources/views/shows/content.blade.php
+++ b/resources/views/shows/content.blade.php
@@ -69,5 +69,6 @@
 <script>
 var showID = "{{ $show->id }}";
 </script>
+<script src="/js/pages/shows/submitform.js" defer></script>
 <script src="/js/pages/shows/content.js" defer></script>
 @endpush

--- a/resources/views/shows/schedule.blade.php
+++ b/resources/views/shows/schedule.blade.php
@@ -32,5 +32,6 @@
 <script>
 var showID = "{{ $show->id }}";
 </script>
+<script src="/js/pages/shows/submitform.js" defer></script>
 <script src="/js/pages/shows/schedule.js" defer></script>
 @endpush

--- a/resources/views/shows/schedule.blade.php
+++ b/resources/views/shows/schedule.blade.php
@@ -10,7 +10,7 @@
                 @if($show->track->weekly)
                     @include('shows.weekly')
                 @endif
-                <h2>Additional details</h2>
+                <h2 dusk="schedule-standard-return">Additional details</h2>
                 <div id="scheduling-extras">
                     @foreach($show->track->scheduling as $field)
                         @include('fields.'.$field['type'], ['category' => 'scheduling', 'value' => $show->scheduling[$field['db']]])

--- a/resources/views/shows/weekly.blade.php
+++ b/resources/views/shows/weekly.blade.php
@@ -80,7 +80,7 @@
 <conflict-list></conflict-list>
 <div class="d-flex mb-2 mt-4 align-items-center flex-wrap">
     <h2>Preferences</h2>
-    <button type="button" class="btn btn-primary ml-auto" id="add-preference-button">
+    <button type="button" class="btn btn-primary ml-auto" id="add-preference-button" dusk="add-preference-button">
         <i class="fas fa-plus"></i> Add preference
     </button>
 </div>

--- a/resources/views/shows/weekly.blade.php
+++ b/resources/views/shows/weekly.blade.php
@@ -72,7 +72,7 @@
 </div>
 <div class="d-flex mb-2 mt-4 align-items-center flex-wrap">
     <h2>Other conflicts</h2>
-    <button type="button" class="btn btn-primary ml-auto" id="add-conflict-button">
+    <button type="button" class="btn btn-primary ml-auto" id="add-conflict-button" dusk="add-conflict-button">
         <i class="fas fa-plus"></i> Add conflict
     </button>
 </div>

--- a/resources/views/shows/weekly.blade.php
+++ b/resources/views/shows/weekly.blade.php
@@ -46,7 +46,7 @@
     @endforeach
 </div>
 <h2>Classes</h2>
-<p>Most common class times are listed here. PE classes, comps, and St. Olaf class times will need to be entered manually.</p>
+<p>Most common class times are listed here. Hover over a class time for details. If you have other classes that don't fit neatly in the standard schedule, add them as conflicts below.</p>
 <div class="row mb-3">
     @foreach(config('classes.groups') as $group)
         <div class="col-sm-6 col-md-4 mb-3">
@@ -56,12 +56,13 @@
                     $dispTimes = array_map(function($time) {
                         $start = Carbon\Carbon::parse($time['start']);
                         $end = Carbon\Carbon::parse($time['end']);
-                        return implode(', ', $time['days']).' '.$start->format('g:i a').' - '.$end->format('g:i a');
+                        $days = array_map(function($day) { return substr($day, 0, $day[0] == 'T' ? 2 : 1); }, $time['days']);
+                        return implode(', ', $days).' '.$start->format('g:i a').' - '.$end->format('g:i a');
                     }, config("classes.times.$block.displayTimes"));
                 @endphp
                 <div class="custom-control custom-checkbox">
                     <input type="checkbox" id="classes-{{ $block }}" name="classes" class="custom-control-input" value="{{ $block }}" {{ in_array($block, $show->classes) ? 'checked' : '' }}>
-                    <label class="custom-control-label" for="classes-{{ $block }}" data-toggle="tooltip" data-placement="bottom" title="{{ implode('; ', $dispTimes) }}">
+                    <label class="custom-control-label" for="classes-{{ $block }}" data-toggle="tooltip" data-placement="bottom" data-html="true" title="{{ implode('<br>', $dispTimes) }}">
                         {{ config("classes.times.$block.name") }}
                     </label>
                 </div>

--- a/tests/Browser/ShowTest.php
+++ b/tests/Browser/ShowTest.php
@@ -7,12 +7,13 @@ use KRLX\Term;
 use KRLX\User;
 use Tests\DuskTestCase;
 use Laravel\Dusk\Browser;
+use Illuminate\Foundation\Testing\WithFaker;
 use Tests\Browser\Pages\Shows\Create as CreatePage;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class ShowTest extends DuskTestCase
 {
-    use DatabaseMigrations;
+    use DatabaseMigrations, WithFaker;
 
     public $track;
     public $term;
@@ -64,16 +65,22 @@ class ShowTest extends DuskTestCase
      */
     public function testValidationOnlyRunsOnCurrentField()
     {
+        $faker = $this->faker();
+        $title = $faker->regexify('[A-Z]{12}');
         $this->browse(function (Browser $browser) {
-            $this->assertCount(1, Term::all());
-
             $browser->loginAs($this->user)
                     ->visit("/shows/{$this->show->id}/content")
                     ->type('title', 'A')
                     ->click('#description')
                     ->pause(500)
                     ->assertSee('The title must be at least')
-                    ->assertDontSee('The description must be at least');
+                    ->assertDontSee('The description must be at least')
+                    ->type('title', $title)
+                    ->click('#description')
+                    ->pause(500)
+                    ->assertDontSee('The title must be at least');
+
+            $this->assertEquals($title, $this->show->title);
         });
     }
 }

--- a/tests/Browser/ShowTest.php
+++ b/tests/Browser/ShowTest.php
@@ -7,13 +7,12 @@ use KRLX\Term;
 use KRLX\User;
 use Tests\DuskTestCase;
 use Laravel\Dusk\Browser;
-use Illuminate\Foundation\Testing\WithFaker;
 use Tests\Browser\Pages\Shows\Create as CreatePage;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 
 class ShowTest extends DuskTestCase
 {
-    use DatabaseMigrations, WithFaker;
+    use DatabaseMigrations;
 
     public $track;
     public $term;
@@ -65,8 +64,6 @@ class ShowTest extends DuskTestCase
      */
     public function testValidationOnlyRunsOnCurrentField()
     {
-        $faker = $this->faker();
-        $title = $faker->regexify('[A-Z]{12}');
         $this->browse(function (Browser $browser) {
             $browser->loginAs($this->user)
                     ->visit("/shows/{$this->show->id}/content")
@@ -75,12 +72,13 @@ class ShowTest extends DuskTestCase
                     ->pause(500)
                     ->assertSee('The title must be at least')
                     ->assertDontSee('The description must be at least')
-                    ->type('title', $title)
+                    ->type('title', 'Amazing Show Title')
                     ->click('#description')
                     ->pause(500)
-                    ->assertDontSee('The title must be at least');
-
-            $this->assertEquals($title, $this->show->title);
+                    ->assertDontSee('The title must be at least')
+                    ->assertSee('Changes saved');
         });
+        $show = Show::find($this->show->id);
+        $this->assertEquals('Amazing Show Title', $show->title);
     }
 }

--- a/tests/Browser/ShowTest.php
+++ b/tests/Browser/ShowTest.php
@@ -84,6 +84,25 @@ class ShowTest extends DuskTestCase
     }
 
     /**
+     * Test that the preferred show times box updates the end time to be offset
+     * by the preferred show length whenever the start time is changed.
+     *
+     * @return void
+     */
+    public function testPreferredEndTimeOffsetToSetLength()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->loginAs($this->user)
+                    ->visit("/shows/{$this->show->id}/schedule")
+                    ->click('@add-preference-button')
+                    ->waitFor('@preference-manager-modal')
+                    ->select('preference-start', '13:00')
+                    ->pause(500)
+                    ->assertSelected('preference-end', '14:00');
+        });
+    }
+
+    /**
      * Test that the "content" prefix doesn't appear in error messages.
      *
      * @return void

--- a/tests/Browser/ShowTest.php
+++ b/tests/Browser/ShowTest.php
@@ -94,6 +94,7 @@ class ShowTest extends DuskTestCase
         $this->browse(function (Browser $browser) {
             $browser->loginAs($this->user)
                     ->visit("/shows/{$this->show->id}/schedule")
+                    ->mouseover('@schedule-standard-return')
                     ->click('@add-preference-button')
                     ->waitFor('@preference-manager-modal')
                     ->select('preference-start', '13:00')

--- a/tests/Browser/ShowTest.php
+++ b/tests/Browser/ShowTest.php
@@ -110,5 +110,6 @@ class ShowTest extends DuskTestCase
                     ->pause(500)
                     ->assertSee('The sponsor must be at least')
                     ->assertDontSee('The content.sponsor must be at least');
+        });
     }
 }

--- a/tests/Browser/ShowTest.php
+++ b/tests/Browser/ShowTest.php
@@ -93,7 +93,7 @@ class ShowTest extends DuskTestCase
         $track = factory(Track::class)->create([
             'active' => true,
             'content' => [
-                ['name' => 'Sponsor', 'db' => 'sponsor', 'type' => 'shorttext', 'helptext' => null, 'rules' => ['required', 'min:3']]
+                ['title' => 'Sponsor', 'db' => 'sponsor', 'type' => 'shorttext', 'helptext' => null, 'rules' => ['required', 'min:3']]
             ]
         ]);
         $show = factory(Show::class)->create([
@@ -102,10 +102,10 @@ class ShowTest extends DuskTestCase
         ]);
         $this->user->shows()->attach($show, ['accepted' => true]);
 
-        $this->browse(function (Browser $browser) {
+        $this->browse(function (Browser $browser) use ($show) {
             $browser->loginAs($this->user)
-                    ->visit("/shows/{$this->show->id}/content")
-                    ->type('content.sponsor', 'A')
+                    ->visit("/shows/{$show->id}/content")
+                    ->type('#sponsor', 'A')
                     ->click('#title')
                     ->pause(500)
                     ->assertSee('The sponsor must be at least')

--- a/tests/Browser/ShowTest.php
+++ b/tests/Browser/ShowTest.php
@@ -53,7 +53,27 @@ class ShowTest extends DuskTestCase
                     ->click('@create-show');
 
             $show = Show::where('title', 'Example Show')->first();
-            $browser->assertRouteIs('shows.participants', $show->id);
+            $browser->assertRouteIs('shows.hosts', $show->id);
+        });
+    }
+
+    /**
+     * Test that validation only runs on the affected field.
+     *
+     * @return void
+     */
+    public function testValidationOnlyRunsOnCurrentField()
+    {
+        $this->browse(function (Browser $browser) {
+            $this->assertCount(1, Term::all());
+
+            $browser->loginAs($this->user)
+                    ->visit("/shows/{$this->show->id}/content")
+                    ->type('title', 'A')
+                    ->click('#description')
+                    ->pause(500)
+                    ->assertSee('The title must be at least')
+                    ->assertDontSee('The description must be at least');
         });
     }
 }

--- a/tests/Browser/ShowTest.php
+++ b/tests/Browser/ShowTest.php
@@ -132,4 +132,34 @@ class ShowTest extends DuskTestCase
                     ->assertDontSee('The content.sponsor must be at least');
         });
     }
+
+    /**
+     * Test that conflicts/preferences without any days selected don't save.
+     *
+     * @return void
+     */
+    public function testConflictsAndPreferencesWithoutDaysDontSave()
+    {
+        $this->browse(function (Browser $browser) {
+            $browser->loginAs($this->user)
+                    ->visit("/shows/{$this->show->id}/schedule")
+                    ->mouseover('@schedule-standard-return')
+                    ->click('@add-conflict-button')
+                    ->waitFor('@conflict-manager-modal')
+                    ->select('conflict-start', '13:00')
+                    ->select('conflict-end', '14:00')
+                    ->click('@save-conflict')
+                    ->waitUntilMissing('@conflict-manager-modal')
+                    ->assertDontSee('1:00 pm - 2:00 pm')
+
+                    ->mouseover('@schedule-standard-return')
+                    ->click('@add-preference-button')
+                    ->waitFor('@preference-manager-modal')
+                    ->select('preference-start', '13:00')
+                    ->select('preference-strength', 3)
+                    ->click('@save-preference')
+                    ->waitUntilMissing('@preference-manager-modal')
+                    ->assertDontSee('First Choice');
+        });
+    }
 }


### PR DESCRIPTION
Thanks to some great forensic work by beta testers, we've got a good number of issues closed for an 0.6.1 bug fix release.

- #44 Diagnose remaining 422 errors on scheduling API
- #45 Refactor submitForm() in shows/weekly.js
- #46 Resolve duplication in shows/weekly.js
- #47 Resolve duplication between shows/content.js and shows/schedule.js
- #57 Automatically determine preference end times based on preferred show length (thanks for the suggestion, Margaret Anne!)
- #60 Drop field parent in validation fault messages (thanks for the reports, Lena and Jenny!)
- #61 Only validate one field at a time (thanks for the report, Lena!)
- #62 Don't save conflicts/preferences unless at least one day is selected