### PR TITLE
Add a profanity rule

### DIFF
--- a/app/Http/Requests/ShowUpdateRequest.php
+++ b/app/Http/Requests/ShowUpdateRequest.php
@@ -3,6 +3,7 @@
 namespace KRLX\Http\Requests;
 
 use KRLX\Track;
+use KRLX\Rules\Profanity;
 use Illuminate\Foundation\Http\FormRequest;
 
 class ShowUpdateRequest extends FormRequest
@@ -49,7 +50,7 @@ class ShowUpdateRequest extends FormRequest
     {
         $baseRules = [
             'submitted' => ['boolean'],
-            'title' => ['string', 'min:3', 'max:200'],
+            'title' => ['string', 'min:3', 'max:200', new Profanity],
             'content' => ['array'],
             'scheduling' => ['array'],
             'conflicts' => ['array', 'min:0'],

--- a/app/Rules/Profanity.php
+++ b/app/Rules/Profanity.php
@@ -41,6 +41,18 @@ class Profanity implements Rule
             }
         }
 
+        return $this->partialWordsPass($value);
+    }
+
+    /**
+     * Check the partial words - these are words which could appear as they
+     * normally are, or in any number of creative derivatives.
+     *
+     * @param  mixed  $value
+     * @return bool
+     */
+    protected function partialWordsPass($value)
+    {
         $bad_words = [];
         foreach (config('defaults.banned_words.partial') as $bad_word) {
             $bad_words[$bad_word] = [

--- a/app/Rules/Profanity.php
+++ b/app/Rules/Profanity.php
@@ -46,12 +46,13 @@ class Profanity implements Rule
                 $bad_word,
                 str_plural($bad_word),
                 $bad_word[0].str_repeat('*', strlen($bad_word)-1),
-                $bad_word[0].str_repeat('*', strlen($bad_word)-1).$bad_word[-1]
+                $bad_word[0].str_repeat('*', strlen($bad_word)-2).$bad_word[-1]
             ];
         }
+        $target = preg_replace('/[!@#\$%\^]/', '*', strtolower($value));
         foreach($bad_words as $word => $derivatives) {
             foreach($derivatives as $derivative) {
-                if(strpos(strtolower($value), $derivative) !== false) {
+                if(strpos($target, $derivative) !== false) {
                     $this->word = $word;
                     return false;
                 }

--- a/app/Rules/Profanity.php
+++ b/app/Rules/Profanity.php
@@ -33,19 +33,28 @@ class Profanity implements Rule
     public function passes($attribute, $value)
     {
         $words = explode(' ', strtolower($value));
-        foreach (array_merge(config('defaults.banned_words.full'), config('defaults.banned_words.partial')) as $bad_word) {
-            if (in_array($bad_word, $words) or in_array(str_plural($bad_word), $words)) {
+        foreach(array_merge(config('defaults.banned_words.full'), config('defaults.banned_words.partial')) as $bad_word) {
+            if(in_array($bad_word, $words) or in_array(str_plural($bad_word), $words)) {
                 $this->word = $bad_word;
-
                 return false;
             }
         }
 
-        foreach (config('defaults.banned_words.partial') as $bad_word) {
-            if (strpos(strtolower($value), $bad_word) !== false or strpos(strtolower($value), str_plural($bad_word)) !== false) {
-                $this->word = $bad_word;
-
-                return false;
+        $bad_words = [];
+        foreach(config('defaults.banned_words.partial') as $bad_word) {
+            $bad_words[$bad_word] = [
+                $bad_word,
+                str_plural($bad_word),
+                $bad_word[0].str_repeat('*', strlen($bad_word)-1),
+                $bad_word[0].str_repeat('*', strlen($bad_word)-1).$bad_word[-1]
+            ];
+        }
+        foreach($bad_words as $word => $derivatives) {
+            foreach($derivatives as $derivative) {
+                if(strpos(strtolower($value), $derivative) !== false) {
+                    $this->word = $word;
+                    return false;
+                }
             }
         }
 

--- a/app/Rules/Profanity.php
+++ b/app/Rules/Profanity.php
@@ -49,7 +49,7 @@ class Profanity implements Rule
                 $bad_word[0].str_repeat('*', strlen($bad_word)-2).$bad_word[-1]
             ];
         }
-        $target = preg_replace('/[!@#\$%\^]/', '*', strtolower($value));
+        $target = preg_replace('/[@#\$%\^]/', '*', strtolower($value));
         foreach($bad_words as $word => $derivatives) {
             foreach($derivatives as $derivative) {
                 if(strpos($target, $derivative) !== false) {

--- a/app/Rules/Profanity.php
+++ b/app/Rules/Profanity.php
@@ -33,16 +33,18 @@ class Profanity implements Rule
     public function passes($attribute, $value)
     {
         $words = explode(' ', strtolower($value));
-        foreach(array_merge(config('defaults.banned_words.full'), config('defaults.banned_words.partial')) as $bad_word) {
-            if(in_array($bad_word, $words) or in_array(str_plural($bad_word), $words)) {
+        foreach (array_merge(config('defaults.banned_words.full'), config('defaults.banned_words.partial')) as $bad_word) {
+            if (in_array($bad_word, $words) or in_array(str_plural($bad_word), $words)) {
                 $this->word = $bad_word;
+
                 return false;
             }
         }
 
-        foreach(config('defaults.banned_words.partial') as $bad_word) {
-            if(strpos(strtolower($value), $bad_word) !== false or strpos(strtolower($value), str_plural($bad_word)) !== false) {
+        foreach (config('defaults.banned_words.partial') as $bad_word) {
+            if (strpos(strtolower($value), $bad_word) !== false or strpos(strtolower($value), str_plural($bad_word)) !== false) {
                 $this->word = $bad_word;
+
                 return false;
             }
         }

--- a/app/Rules/Profanity.php
+++ b/app/Rules/Profanity.php
@@ -33,27 +33,29 @@ class Profanity implements Rule
     public function passes($attribute, $value)
     {
         $words = explode(' ', strtolower($value));
-        foreach(array_merge(config('defaults.banned_words.full'), config('defaults.banned_words.partial')) as $bad_word) {
-            if(in_array($bad_word, $words) or in_array(str_plural($bad_word), $words)) {
+        foreach (array_merge(config('defaults.banned_words.full'), config('defaults.banned_words.partial')) as $bad_word) {
+            if (in_array($bad_word, $words) or in_array(str_plural($bad_word), $words)) {
                 $this->word = $bad_word;
+
                 return false;
             }
         }
 
         $bad_words = [];
-        foreach(config('defaults.banned_words.partial') as $bad_word) {
+        foreach (config('defaults.banned_words.partial') as $bad_word) {
             $bad_words[$bad_word] = [
                 $bad_word,
                 str_plural($bad_word),
-                $bad_word[0].str_repeat('*', strlen($bad_word)-1),
-                $bad_word[0].str_repeat('*', strlen($bad_word)-2).$bad_word[-1]
+                $bad_word[0].str_repeat('*', strlen($bad_word) - 1),
+                $bad_word[0].str_repeat('*', strlen($bad_word) - 2).$bad_word[-1],
             ];
         }
         $target = preg_replace('/[@#\$%\^]/', '*', strtolower($value));
-        foreach($bad_words as $word => $derivatives) {
-            foreach($derivatives as $derivative) {
-                if(strpos($target, $derivative) !== false) {
+        foreach ($bad_words as $word => $derivatives) {
+            foreach ($derivatives as $derivative) {
+                if (strpos($target, $derivative) !== false) {
                     $this->word = $word;
+
                     return false;
                 }
             }

--- a/app/Rules/Profanity.php
+++ b/app/Rules/Profanity.php
@@ -56,7 +56,7 @@ class Profanity implements Rule
     {
         $bad_words = $this->assembleDerivatives();
         foreach ($bad_words as $word => $derivatives) {
-            if (! singleWordDerivativesPass($word, $derivatives, $value)) {
+            if (! $this->singleWordDerivativesPass($word, $derivatives, $value)) {
                 return false;
             }
         }

--- a/app/Rules/Profanity.php
+++ b/app/Rules/Profanity.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace KRLX\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class Profanity implements Rule
+{
+    /**
+     * The word that has been found.
+     *
+     * @var string|null
+     */
+    public $word;
+
+    /**
+     * Create a new rule instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $words = explode(' ', strtolower($value));
+        foreach(array_merge(config('defaults.banned_words.full'), config('defaults.banned_words.partial')) as $bad_word) {
+            if(in_array($bad_word, $words) or in_array(str_plural($bad_word), $words)) {
+                $this->word = $bad_word;
+                return false;
+            }
+        }
+
+        foreach(config('defaults.banned_words.partial') as $bad_word) {
+            if(strpos(strtolower($value), $bad_word) !== false or strpos(strtolower($value), str_plural($bad_word)) !== false) {
+                $this->word = $bad_word;
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     *
+     * @return string
+     */
+    public function message()
+    {
+        return "The word {$this->word} can't appear in the :attribute.";
+    }
+}

--- a/app/Rules/Profanity.php
+++ b/app/Rules/Profanity.php
@@ -32,7 +32,8 @@ class Profanity implements Rule
      */
     public function passes($attribute, $value)
     {
-        $words = explode(' ', strtolower($value));
+        $target = preg_replace('/[@#\$%\^]/', '*', strtolower($value));
+        $words = explode(' ', $target);
         foreach (array_merge(config('defaults.banned_words.full'), config('defaults.banned_words.partial')) as $bad_word) {
             if (in_array($bad_word, $words) or in_array(str_plural($bad_word), $words)) {
                 $this->word = $bad_word;
@@ -41,7 +42,7 @@ class Profanity implements Rule
             }
         }
 
-        return $this->partialWordsPass($value);
+        return $this->partialWordsPass($target);
     }
 
     /**
@@ -53,9 +54,7 @@ class Profanity implements Rule
      */
     protected function partialWordsPass($value)
     {
-        $bad_words = $this->assembleDerivatives();
-        $target = preg_replace('/[@#\$%\^]/', '*', strtolower($value));
-        foreach ($bad_words as $word => $derivatives) {
+        foreach ($this->assembleDerivatives() as $word => $derivatives) {
             foreach ($derivatives as $derivative) {
                 if (strpos($target, $derivative) !== false) {
                     $this->word = $word;

--- a/app/Rules/Profanity.php
+++ b/app/Rules/Profanity.php
@@ -53,15 +53,7 @@ class Profanity implements Rule
      */
     protected function partialWordsPass($value)
     {
-        $bad_words = [];
-        foreach (config('defaults.banned_words.partial') as $bad_word) {
-            $bad_words[$bad_word] = [
-                $bad_word,
-                str_plural($bad_word),
-                $bad_word[0].str_repeat('*', strlen($bad_word) - 1),
-                $bad_word[0].str_repeat('*', strlen($bad_word) - 2).$bad_word[-1],
-            ];
-        }
+        $bad_words = $this->assembleDerivatives();
         $target = preg_replace('/[@#\$%\^]/', '*', strtolower($value));
         foreach ($bad_words as $word => $derivatives) {
             foreach ($derivatives as $derivative) {
@@ -74,6 +66,25 @@ class Profanity implements Rule
         }
 
         return true;
+    }
+
+    /**
+     * Assemble the derivatives list used in partial word validation.
+     *
+     * @return array
+     */
+    protected function assembleDerivatives()
+    {
+        $bad_words = [];
+        foreach (config('defaults.banned_words.partial') as $bad_word) {
+            $bad_words[$bad_word] = [
+                $bad_word,
+                str_plural($bad_word),
+                $bad_word[0].str_repeat('*', strlen($bad_word) - 1),
+                $bad_word[0].str_repeat('*', strlen($bad_word) - 2).$bad_word[-1],
+            ];
+        }
+        return $bad_words;
     }
 
     /**

--- a/app/Rules/Profanity.php
+++ b/app/Rules/Profanity.php
@@ -54,13 +54,31 @@ class Profanity implements Rule
      */
     protected function partialWordsPass($value)
     {
-        foreach ($this->assembleDerivatives() as $word => $derivatives) {
-            foreach ($derivatives as $derivative) {
-                if (strpos($target, $derivative) !== false) {
-                    $this->word = $word;
+        $bad_words = $this->assembleDerivatives();
+        foreach ($bad_words as $word => $derivatives) {
+            if (! singleWordDerivativesPass($word, $derivatives, $value)) {
+                return false;
+            }
+        }
 
-                    return false;
-                }
+        return true;
+    }
+
+    /**
+     * Check if a single word's derivatives show up.
+     *
+     * @param  string  $word
+     * @param  array  $derivatives
+     * @param  string  $value
+     * @return bool
+     */
+    private function singleWordDerivativesPass($word, $derivatives, $value)
+    {
+        foreach ($derivatives as $derivative) {
+            if (strpos($value, $derivative) !== false) {
+                $this->word = $word;
+
+                return false;
             }
         }
 

--- a/config/defaults.php
+++ b/config/defaults.php
@@ -2,7 +2,7 @@
 
 return [
     'banned_words' => [
-        /**
+        /*
          * The following words are not allowed in show titles, or any other
          * custom validation field that has a "profanity" flag on it. This list
          * is adapted from the UK Office of Communications' 2010 study on
@@ -11,7 +11,7 @@ return [
          */
         'partial' => ['shit', 'piss', 'fuck', 'cunt', 'cock', 'tit', 'bitch', 'bastard'],
 
-        /**
+        /*
          * These words must be present in isolation to trigger a fault (usually
          * because there are "safe" words that include these strings, such as
          * "pass" being a safe word)

--- a/config/defaults.php
+++ b/config/defaults.php
@@ -1,6 +1,23 @@
 <?php
 
 return [
+    'banned_words' => [
+        /**
+         * The following words are not allowed in show titles, or any other
+         * custom validation field that has a "profanity" flag on it. This list
+         * is adapted from the UK Office of Communications' 2010 study on
+         * acceptable language to use in broadcasting. Presence of any of these
+         * strings, even in longer words, will throw a validation fault.
+         */
+        'partial' => ['shit', 'piss', 'fuck', 'cunt', 'cock', 'tit', 'bitch', 'bastard'],
+
+        /**
+         * These words must be present in isolation to trigger a fault (usually
+         * because there are "safe" words that include these strings, such as
+         * "pass" being a safe word)
+         */
+        'full' => ['ass', 'asshole', 'pussy'],
+    ],
     'directory' => 'https://apps.carleton.edu/stock/ldapimage.php?id=',
     'title' => 'KRLX Community',
     'salt' => env('OAUTH_SALT', 'krlx'),

--- a/tests/Feature/CustomRuleTest.php
+++ b/tests/Feature/CustomRuleTest.php
@@ -74,7 +74,7 @@ class CustomRuleTest extends TestCase
             $request = $this->actingAs($user, 'api')->json('PATCH', "/api/v1/shows/{$show->id}", [
                 'title' => $word,
             ]);
-            if($request->status() == 500) {
+            if ($request->status() == 500) {
                 dump($request->json());
             }
             $this->assertEquals(200, $request->status(), "Did not receive HTTP 200 with word $word.");

--- a/tests/Feature/CustomRuleTest.php
+++ b/tests/Feature/CustomRuleTest.php
@@ -68,6 +68,7 @@ class CustomRuleTest extends TestCase
         $good_words = [
             'prefix'.$full,
             'hole',
+            'pals!!!',
         ];
         foreach ($good_words as $word) {
             $request = $this->actingAs($user, 'api')->json('PATCH', "/api/v1/shows/{$show->id}", [

--- a/tests/Feature/CustomRuleTest.php
+++ b/tests/Feature/CustomRuleTest.php
@@ -62,6 +62,8 @@ class CustomRuleTest extends TestCase
             $full,
             str_plural($full),
             'F***',
+            'F**k',
+            'F@$#',
         ];
         $good_words = [
             'prefix'.$full,

--- a/tests/Feature/CustomRuleTest.php
+++ b/tests/Feature/CustomRuleTest.php
@@ -74,6 +74,9 @@ class CustomRuleTest extends TestCase
             $request = $this->actingAs($user, 'api')->json('PATCH', "/api/v1/shows/{$show->id}", [
                 'title' => $word,
             ]);
+            if($request->status() == 500) {
+                dump($request->json());
+            }
             $this->assertEquals(200, $request->status(), "Did not receive HTTP 200 with word $word.");
         }
         foreach ($bad_words as $word) {

--- a/tests/Feature/CustomRuleTest.php
+++ b/tests/Feature/CustomRuleTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Feature;
 
+use KRLX\Show;
+use KRLX\User;
 use KRLX\Track;
 use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -37,6 +39,45 @@ class CustomRuleTest extends TestCase
             array_set($data, 'content.0.rules', [$rule]);
             $request = $this->json('PATCH', "/api/v1/tracks/{$track->id}", $data);
             $this->assertEquals(422, $request->status(), "Did not receive HTTP 422 on rule $rule.");
+        }
+    }
+
+    /**
+     * Test the "Profanity" validation rule: Does a string contain bad words?
+     *
+     * @return void
+     */
+    public function testProfanityRule()
+    {
+        $show = factory(Show::class)->create();
+        $user = factory(User::class)->create();
+        $show->hosts()->attach($user, ['accepted' => true]);
+
+        $partial = config('defaults.banned_words.partial')[0];
+        $full = config('defaults.banned_words.full')[0];
+        $bad_words = [
+            $partial,
+            $partial.'hole',
+            str_plural($partial),
+            $full,
+            str_plural($full)
+        ];
+        $good_words = [
+            'prefix'.$full,
+            'hole'
+        ];
+        foreach($good_words as $word) {
+            $request = $this->actingAs($user, 'api')->json('PATCH', "/api/v1/shows/{$show->id}", [
+                'title' => $word
+            ]);
+            $this->assertEquals(200, $request->status(), "Did not receive HTTP 200 with word $word.");
+        }
+        foreach($bad_words as $word) {
+            $request = $this->actingAs($user, 'api')->json('PATCH', "/api/v1/shows/{$show->id}", [
+                'title' => $word
+            ]);
+            $this->assertEquals(422, $request->status(), "Did not receive HTTP 422 with word $word.");
+            $this->assertNotEquals('The word  can\'t appear in the title', array_get($request->json(), 'errors.title.0'));
         }
     }
 }

--- a/tests/Feature/CustomRuleTest.php
+++ b/tests/Feature/CustomRuleTest.php
@@ -61,6 +61,7 @@ class CustomRuleTest extends TestCase
             str_plural($partial),
             $full,
             str_plural($full),
+            'F***',
         ];
         $good_words = [
             'prefix'.$full,

--- a/tests/Feature/CustomRuleTest.php
+++ b/tests/Feature/CustomRuleTest.php
@@ -60,21 +60,21 @@ class CustomRuleTest extends TestCase
             $partial.'hole',
             str_plural($partial),
             $full,
-            str_plural($full)
+            str_plural($full),
         ];
         $good_words = [
             'prefix'.$full,
-            'hole'
+            'hole',
         ];
-        foreach($good_words as $word) {
+        foreach ($good_words as $word) {
             $request = $this->actingAs($user, 'api')->json('PATCH', "/api/v1/shows/{$show->id}", [
-                'title' => $word
+                'title' => $word,
             ]);
             $this->assertEquals(200, $request->status(), "Did not receive HTTP 200 with word $word.");
         }
-        foreach($bad_words as $word) {
+        foreach ($bad_words as $word) {
             $request = $this->actingAs($user, 'api')->json('PATCH', "/api/v1/shows/{$show->id}", [
-                'title' => $word
+                'title' => $word,
             ]);
             $this->assertEquals(422, $request->status(), "Did not receive HTTP 422 with word $word.");
             $this->assertNotEquals('The word  can\'t appear in the title', array_get($request->json(), 'errors.title.0'));


### PR DESCRIPTION
Okay, it's not perfect, but the `profanity` rule should now catch a lot of attempts at including Bad Words™ in show titles.